### PR TITLE
add some survival raid cooldowns

### DIFF
--- a/data/Deathknight.lua
+++ b/data/Deathknight.lua
@@ -20,7 +20,7 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("DEATHKNIGHT", "50400", 2, {
+lib:__RegisterSpells("DEATHKNIGHT", "50400", 3, {
 	COOLDOWN = {
 		42650, -- Army of the Dead
 		61999, -- Raise Ally
@@ -33,7 +33,8 @@ lib:__RegisterSpells("DEATHKNIGHT", "50400", 2, {
 		},
 		AURA = {
 			HELPFUL = {
-				49016, -- Unholy Frenzy
+				  49016, -- Unholy Frenzy
+				[145629] = 'SURVIVAL', -- Anti-Magic Zone
 			},
 			HARMFUL = {
 				49206, -- Summon Gargoyle
@@ -47,7 +48,6 @@ lib:__RegisterSpells("DEATHKNIGHT", "50400", 2, {
 				SURVIVAL = {
 					 49039, -- Lichborne
 					 48707, -- Anti-Magic Shell
-					145629, -- Anti-Magic Zone
 					 48792, -- Icebound Fortitude
 					 81256, -- Dancing Rune Weapon
 					 49222, -- Bone Shield
@@ -105,13 +105,13 @@ lib:__RegisterSpells("DEATHKNIGHT", "50400", 2, {
 	[ 59052] =  59057, -- Freezing Fog <= Rime
 	[ 81340] =  49530, -- Sudden Doom
 	[ 91342] =  49572, -- Shadow Infusion
-	[115635] =  63333, -- Death Barrier <= Glyph of Death Coil     -- TODO: glyph detection does not work
+	[115635] =  63333, -- Death Barrier <= Glyph of Death Coil
 	[114851] =  45529, -- Blood Charge <= Blood Tap                -- NOTE: stack count covered by the default ui
 	[ 91802] =  47482, -- Shambling Rush <= Leap (Ghoul)
 	[ 91800] =  47481, -- Gnaw (Ghoul)
 	[ 91797] =  47481, -- Monstrous Blow <= Gnaw (Ghoul)
 	-- map spell id to provider?
-	[ 45477] =  58631, -- Icy Touch <= Glyph of Icy Touch          -- TODO: glyph detection does not work
+	[ 45477] =  58631, -- Icy Touch <= Glyph of Icy Touch
 
 }, {
 	-- Map aura to modified spell(s)

--- a/data/Monk.lua
+++ b/data/Monk.lua
@@ -20,7 +20,7 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("MONK", "50400", 9, {
+lib:__RegisterSpells("MONK", "50400", 10, {
 	COOLDOWN = {
 		109132, -- Roll
 		113656, -- Fists of Fury
@@ -46,14 +46,14 @@ lib:__RegisterSpells("MONK", "50400", 9, {
 				 124081, -- Zen Sphere
 				[116844] = "SURVIVAL", -- Ring of Peace
 				[116849] = "SURVIVAL", -- Life Cocoon
+				[115213] = "SURVIVAL", -- Avert Harm
+				[131523] = "SURVIVAL", -- Zen Meditation
 			},
 			PERSONAL = {
 				[115288] = "POWER_REGEN", -- Energizing Brew
 				SURVIVAL = {
 					115295, -- Guard
-					115176, -- Zen Meditation
 					115203, -- Fortifying Brew
-					115213, -- Avert Harm
 					122278, -- Dampen Harm
 					122470, -- Touch of Karma
 					122783, -- Diffuse Magic
@@ -118,6 +118,7 @@ lib:__RegisterSpells("MONK", "50400", 9, {
 	[123727] = 121253, -- Dizzying Haze (debuff) <- Keg Smash
 	[124458] = 115460, -- Healing Sphere
 	[130320] = 107428, -- Rising Sun Kick
+	[131523] = 115176, -- Zen Meditation
 }, {
 	-- Map aura to modified spell(s)
 	[115307] = 100784, -- Shuffle -> Blackout Kick

--- a/data/Paladin.lua
+++ b/data/Paladin.lua
@@ -20,24 +20,27 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("PALADIN", "50400", 3, {
+lib:__RegisterSpells("PALADIN", "50400", 4, {
 	[96231] = "COOLDOWN INTERRUPT", -- Rebuke
 	['SURVIVAL COOLDOWN AURA'] = {
 		PERSONAL = {
 			  498, -- Divine Protection
 			  642, -- Divine Shield
-			 6940, -- Hand of Sacrifice
 			31850, -- Ardent Defender
 			54428, -- Divine Plea
 			86659, -- Ancient Guardian (prot)
 		},
 		HELPFUL = {
-			 1022, -- Hand of Protection
+			 31821, -- Devotion Aura
+			  1022, -- Hand of Protection
+			  1044, -- Hand of Freedom
+			  6940, -- Hand of Sacrifice
+			114039, -- Hand of Purity
 		},
 	},
 	AURA = {
 		PERSONAL = {
-			[84963] = 'HELPFUL', -- Inquisition
+			 84963, -- Inquisition
 		},
 	},
 	RAIDBUFF = {

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -20,13 +20,20 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("WARRIOR", "50400", 3, {
+lib:__RegisterSpells("WARRIOR", "50400", 4, {
 	[6552] = "COOLDOWN INTERRUPT", -- Pummel
-	['PERSONAL SURVIVAL COOLDOWN AURA']= {
-		 2565, -- Shield Block
-		55694, -- Enraged Regeneration
-		  871, -- Shield Wall
-		12975, -- Last Stand
+	['SURVIVAL COOLDOWN AURA']= {
+		PERSONAL = {
+			 2565, -- Shield Block
+			55694, -- Enraged Regeneration
+			  871, -- Shield Wall
+			12975, -- Last Stand
+		},
+		HELPFUL = {
+			 97463, -- Rallying Cry
+			114028, -- Mass Spell Reflection
+			114030, -- Vigilance
+		},
 	},
 	RAIDBUFF = {
 		[ 469] = 'STAMINA',   -- Commanding Shout
@@ -34,6 +41,7 @@ lib:__RegisterSpells("WARRIOR", "50400", 3, {
 	},
 }, {
 	-- Map aura to provider
+	[97463] = 97462, -- Rallying Cry
 }, {
 	-- Map aura to modified spell(s)
 })


### PR DESCRIPTION
Add the missing raid survival cooldowns (hopefully now complete). This meant moving some spells from PERSONAL to HELPFUL, because they do apply a raid buff. This is mainly interesting to tanks and they can pull the list by using `:IterateSpells("SURVIVAL", "AURA", "PERSONAL")`.
