### PR TITLE
Fixed Rend and Deep Wounds

### DIFF
--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -84,11 +84,13 @@ lib:__RegisterSpells("WARRIOR", "60000", 4, {
 			159740, -- Glyph of Raging Blow
 			169686, -- Unyielding Strikes (Prot, Talent 45)
 			174926, -- Shield Barrier (Arms, Fury)
+			HARMFUL = {
+				772, -- Rend (Arms)
+				115767, -- Deep Wounds (Prot)
+			},	
 		},
 		HARMFUL = {
-			   772, -- Rend (Arms)
 			  6343, -- Thunder Clap (Slow)
-			115767, -- Deep Wounds (Prot)
 			115804, -- Mortal Wounds (Reduced Healing)
 			129923, -- Sluggish (Glyph of Hindering Strikes)
 		},


### PR DESCRIPTION
Made it so Rend and deep wounds are marked as personal debuffs so they only show the one the player applied.
