### PR TITLE
Warrior: Add "Oppressor" Honor Talent to Warrior.lua

### DIFF
--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -74,6 +74,7 @@ lib:__RegisterSpells("WARRIOR", 70100, 1, {
 						132169, -- Storm Bolt (stun)
 					},
 				},
+				[206891] = "UNIQUE_AURA", -- Intimidated (Protection Honor Talent)
 			},
 		},
 	},
@@ -146,6 +147,7 @@ lib:__RegisterSpells("WARRIOR", 70100, 1, {
 	[205546] = 205545, -- Odyn's Fury (Fury artifact)
 	[206316] = 206315, -- Massacre
 	[206333] = 100130, -- Taste for Blood <- Furious Slash
+	[206891] = 205800, -- Oppressor (Protection Honor Talent)
 	[208086] = { -- Colossus Smash
 		167105, -- Colossus Smash
 		209577, -- Warbreaker (Arms artifact)


### PR DESCRIPTION
Harmful Aura: 206891
Provider Spell: 205800

Added the honor talent as Cooldown with a Harmful Aura, because it
increases damage on the target by 5% for each player that hits the
target, with a maximum of 25%. The debuff is refreshed while you hit it.
Oppressor replaces taunt, and it has a 20 second cooldown.