### PR TITLE
Battle for Azeroth Warrior

### DIFF
--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -26,7 +26,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		  6572, -- Revenge (Protection)
 		 23881, -- Bloodthirst (Fury)
 		 23922, -- Shield Slam (Protection)
-		202168, -- Impending Victory (Protection talent)
+		202168, -- Impending Victory (Protection/Fury talent)
 	       [  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
@@ -38,15 +38,14 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			HARMFUL = {
 				  1160, -- Demoralizing Shout (Protection)
 				105771, -- Charge (Protection/Fury)
+				113344, -- Bloodbath (Fury talent)
 				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
+					[ 355] = "TAUNT", -- Taunt
 					[5246] = "DISORIENT", -- Intimidating Shout (Protection/Fury)
 					STUN = {
 						132168, -- Shockwave (Protection)
-						132169, -- Storm Bolt (Protection talent)
-					},
-					TAUNT = {
-						355, -- Taunt (Protection/Fury)
+						132169, -- Storm Bolt (Protection/Fury talent)
 					},
 				},
 				SNARE = {
@@ -57,19 +56,23 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			PERSONAL = {
 				 18499, -- Berserker Rage (Protection/Fury)
 				 23920, -- Spell Reflection (Protection)
+				 46924, -- Bladestorm (Fury talent)
 				 85739, -- Meat Cleaver (Fury)
+				118000, -- Dragon Roar (fury talent)
 				132404, -- Shield Block (Protection)
-				202164, -- Bounding Stride (Protection talent)
-				227744, -- Ravager (Protection talent)
-				275337, -- Bolster (Protection talent)
+				202164, -- Bounding Stride (Protection/Fury talent)
+				202225, -- Furious Charge (Fury talent)
+				274818, -- Bloodbath (Fury talent)
  				BURST = {
 					  1719, -- Recklessness (Fury)
-					107574, -- Avatar (Protection)
+					107574, -- Avatar (Protection)(Fury talent)
 				},
 				SURVIVAL = {
 					   871, -- Shield Wall (Protection)
 					 12975, -- Last Stand (Protection)
 					184364, -- Enraged Regeneration (Fury)
+					227744, -- Ravager (Protection talent)
+					275337, -- Bolster (Protection talent)
 				},
 			},
 		},
@@ -81,10 +84,15 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		PERSONAL = {
 			 32216, -- Victorious (Protection)
 			184362, -- Enrage (Fury)
+			202539, -- Frenzy (Fury talent)
 			202573, -- Vengeance: Revenge (Protection talent)
 			202574, -- Vengeance: Ignore Pain (Protection talent)
 			202602, -- Into the Fray (Protection talent)
+			206316, -- Massacre (Fury talent)
 			206333, -- Taste for Blood (Fury)
+			215562, -- War Machine (Fury talent)
+			215570, -- Wrecking Ball (Fury talent)
+			215572, -- Frothing Berserker (Fury talent)
 			SURVIVAL = {
 				190456, -- Ignore Pain (Protection)
 			},
@@ -94,7 +102,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	-- Map aura to provider(s)
 	[ 32216] = { -- Victorious (Protection)
 		 34428, -- Victory Rush (Protection)
-		202168, -- Impending Victory (Protection talent)
+		202168, -- Impending Victory (Protection/Fury talent)
 	},
 	[ 85739] = 190411, -- Meat Cleaver -> Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry (Protection)
@@ -102,19 +110,27 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		   100, -- Charge (Fury)
 		198304, -- Intercept - Charge (Protection)
 	},
+	[113344] =  12292, -- Bloodbath (Fury talent)
 	[115767] = 115768, -- Deep Wounds (Protection)
 	[132168] =  46968, -- Shockwave (Protection)
-	[132169] = 107570, -- Storm Bolt (Protection talent)
+	[132169] = 107570, -- Storm Bolt (Protection/Fury talent)
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intercept - Intervene (Protection)
 	[184362] = 184361, -- Enrage (Fury)
-	[202164] = 202163, -- Bounding Stride (Protection talent)
+	[202164] = 202163, -- Bounding Stride (Protection/Fury talent)
+	[202225] = 202224, -- Furious Charge (Fury talent)
+	[202539] = 206313, -- Frenzy (Fury talent)
 	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protectiont talent)
 	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance (Protection talent)
 	[202602] = 202603, -- Into the Fray (Protection talent)
+	[206316] = 206315, -- Massacre (Fury talent)
 	[206333] = 100130, -- Taste for Blood -> Furious Slash
+	[215562] = 215556, -- War Machine (Fury talent)
+	[215570] = 215569, -- Wrecking Ball (Fury talent)
+	[215572] = 215571, -- Frothing Berserker (Fury talent)
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
+	[274818] =  12292, -- Bloodbath (Fury talent)
 	[275335] = 275334, -- Punish (Protection talent)
 }, {
 	-- map aura to modified spell(s)
@@ -128,10 +144,14 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		236279, -- Devastator (Protection talent)
 	},
 	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
-	[202164] =   6544, -- Bounding Stride -> Heroic Leap (Protection talent)
+	[202164] =   6544, -- Bounding Stride -> Heroic Leap (Protection/Fury talent)
+	[202225] =  23881, -- Furious Charge -> Bloodthirst (Fury talent)
+	[202539] = 100130, -- Frenzy -> Furious Slash (Fury talent)
 	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
 	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain (Protection talent)
+	[206316] = 184367, -- Massacre -> Rampage (Fury talent)
 	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
+	[215570] = 190411, -- Wrecking Ball -> Whirlwind (Fury talent)
 	[223658] = 198304, -- Safeguard -> Intercept (Protection talent)
 	[275335] =  23922, -- Punish -> Shield Slam (Protection talent)
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -15,22 +15,22 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
+along with LibPlayerSpells-1.0. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
 lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
-		   845, -- Cleave (Arms talent)
-		  6544, -- Heroic Leap
-		  6572, -- Revenge (Protection)
-		 23881, -- Bloodthirst (Fury)
-		 23922, -- Shield Slam (Protection)
-		152277, -- Ravager (Arms talent)
-		202168, -- Impending Victory (talent)
-		260643, -- Skullsplitter (Arms talent)
-	       [  6552] = "INTERRUPT", -- Pummel
+		    845, -- Cleave (Arms talent)
+		   6544, -- Heroic Leap
+		   6572, -- Revenge (Protection)
+		  23881, -- Bloodthirst (Fury)
+		  23922, -- Shield Slam (Protection)
+		 152277, -- Ravager (Arms talent)
+		 202168, -- Impending Victory (talent)
+		 260643, -- Skullsplitter (Arms talent)
+		[  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
 				  6673, -- Battle Shout
@@ -72,7 +72,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				227847, -- Bladestorm (Arms)
 				260708, -- Sweeping Strikes (Arms)
 				274818, -- Bloodbath (Fury talent)
- 				BURST = {
+				BURST = {
 					  1719, -- Recklessness (Fury)
 					107574, -- Avatar (Protection)(Fury/Arms talent)
 					262228, -- Deadly Calm (Arms talent)
@@ -123,7 +123,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		202168, -- Impending Victory (talent)
 	},
 	[ 52437] =  29725, -- Sudden Death (Arms talent)
-	[ 85739] = 190411, -- Meat Cleaver -> Whirlwind (Fury)
+	[ 85739] = 190411, -- Meat Cleaver <- Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry
 	[105771] = { -- Charge (root)
 		   100, -- Charge (Fury/Arms)
@@ -135,7 +135,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[132168] =  46968, -- Shockwave (Protection)
 	[132169] = 107570, -- Storm Bolt (talent)
 	[132404] =   2565, -- Shield Block (Protection)
-	[147833] = 198304, -- Intercept - Intervene (Protection)
+	[147833] = 198304, -- Intercept <- Intervene (Protection)
 	[184362] = 184361, -- Enrage (Fury)
 	[197690] = 212520, -- Defensive Stance (Arms talent)
 	[202164] = 202163, -- Bounding Stride (talent)
@@ -145,7 +145,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance (Protection talent)
 	[202602] = 202603, -- Into the Fray (Protection talent)
 	[206316] = 206315, -- Massacre (Fury talent)
-	[206333] = 100130, -- Taste for Blood -> Furious Slash
+	[206333] = 100130, -- Taste for Blood <- Furious Slash
 	[208086] = { -- Colossus Smash (Arms)
 		167105, -- Colossus Smash (Arms)
 		262161, -- Warbreaker (Arms talent)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -22,37 +22,43 @@ local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
 lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
-		 6544, -- Heroic Leap (Protection)
-		 6572, -- Revenge (Protection)
-		23922, -- Shield Slam (Protection)
-	       [ 6552] = "INTERRUPT", -- Pummel
+		  6544, -- Heroic Leap (Protection)
+		  6572, -- Revenge (Protection)
+		 23922, -- Shield Slam (Protection)
+		202168, -- Impending Victory (Protection talent)
+	       [  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
 				  6673, -- Battle Shout (Protection)
 				 97463, -- Rallying Cry (Protection)
 				147833, -- Intervene (Protection)
+				223658, -- Safeguard (Protection talent)
 			},
 			HARMFUL = {
 				  1160, -- Demoralizing Shout (Protection)
 				105771, -- Charge (Protection)
+				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
 					[5246] = "DISORIENT", -- Intimidating Shout (Protection)
 					STUN = {
 						132168, -- Shockwave (Protection)
+						132169, -- Storm Bolt (Protection talent)
 					},
 					TAUNT = {
 						355, -- Taunt (Protection)
 					},
 				},
 				SNARE = {
-					6343, -- Thunderclap (Protection)
+					6343, -- Thunder Clap (Protection)
 				},
-
 			},
 			PERSONAL = {
 				 18499, -- Berserker Rage (Protection)
 				 23920, -- Spell Reflection (Protection)
 				132404, -- Shield Block (Protection)
+				202164, -- Bounding Stride (Protection talent)
+				227744, -- Ravager (Protection talent)
+				275337, -- Bolster (Protection talent)
  				BURST = {
 					107574, -- Avatar (Protection)
 				},
@@ -61,7 +67,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 					12975, -- Last Stand (Protection)
 				},
 			},
-
 		},
 	},
 	AURA = {
@@ -69,7 +74,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			115767, -- Deep Wounds (Protection)
 		},
 		PERSONAL = {
-			32216, -- Victorious (Protection)
+			 32216, -- Victorious (Protection)
+			202573, -- Vengeance: Revenge (Protection talent)
+			202574, -- Vengeance: Ignore Pain (Protection talent)
+			202602, -- Into the Fray (Protection talent)
 			SURVIVAL = {
 				190456, -- Ignore Pain (Protection)
 			},
@@ -77,17 +85,34 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 }, {
 	-- Map aura to provider(s)
-	[ 32216] =  34428, -- Victory Rush (Protection)
+	[ 32216] = { -- Victorious (Protection)
+		 34428, -- Victory Rush (Protection)
+		202168, -- Impending Victory (Protection talent)
+	},
 	[ 97463] =  97462, -- Rallying Cry (Protection)
 	[105771] = 198304, -- Intercept - Charge (Protection)
 	[115767] = 115768, -- Deep Wounds (Protection)
 	[132168] =  46968, -- Shockwave (Protection)
+	[132169] = 107570, -- Storm Bolt (Protection talent)
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intercept - Intervene (Protection)
+	[202164] = 202163, -- Bounding Stride (Protection talent)
+	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protectiont talent)
+	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance (Protection talent)
+	[202602] = 202603, -- Into the Fray (Protection talent)
+	[223658] = 223657, -- Safeguard (Protection talent)
+	[227744] = 228920, -- Ravager (Protection talent)
+	[275335] = 275334, -- Punish (Protection talent)
 }, {
 	-- map aura to modified spell(s)
 	[115767] = { -- Deep Wounds (Protection)
-		 6572, -- Revenge (Protection)
-		20243, -- Devestate (Protection)
+		  6572, -- Revenge (Protection)
+		 20243, -- Devestate (Protection)
+		236279, -- Devastator (Protection talent)
 	},
+	[202164] =   6544, -- Bounding Stride -> Heroic Leap (Protection talent)
+	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
+	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain (Protection talent)
+	[223658] = 198304, -- Safeguard -> Intercept (Protection talent)
+	[275335] =  23922, -- Punish -> Shield Slam (Protection talent)
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -25,7 +25,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		    845, -- Cleave (Arms talent)
 		   6544, -- Heroic Leap
 		   6572, -- Revenge (Protection)
-		  23881, -- Bloodthirst (Fury)
 		  57755, -- Heroic Throw
 		 202168, -- Impending Victory (talent)
 		[  6552] = "INTERRUPT", -- Pummel
@@ -68,7 +67,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 					},
 				},
 				SNARE = {
-					 12323, -- Piercing Howl (Fury)
 					[ 6343] = "POWER_REGEN", -- Thunder Clap (Protection)
 				},
 			},
@@ -104,6 +102,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			},
 		},
 		POWER_REGEN = {
+			 23881, -- Bloodthirst (Fury)
 			 23922, -- Shield Slam (Protection)
 			152277, -- Ravager (Arms talent)
 			260643, -- Skullsplitter (Arms talent)
@@ -115,7 +114,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			 115767, -- Deep Wounds (Protection)
 			 215537, -- Trauma (Arms talent)
 			 262115, -- Deep Wounds (Arms)
-			[  1715] = "SNARE", -- Hamstring (Arms)
+			SNARE = {
+				 1715, -- Hamstring (Arms)
+				12323, -- Piercing Howl (Fury)
+			}
 		},
 		PERSONAL = {
 			 32216, -- Victorious

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -26,37 +26,37 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		   6544, -- Heroic Leap
 		   6572, -- Revenge (Protection)
 		  23881, -- Bloodthirst (Fury)
-		  23922, -- Shield Slam (Protection)
 		 152277, -- Ravager (Arms talent)
 		 202168, -- Impending Victory (talent)
 		 260643, -- Skullsplitter (Arms talent)
 		[  6552] = "INTERRUPT", -- Pummel
+		[ 23922] = "POWER_REGEN", -- Shield Slam (Protection)
 		AURA = {
 			HELPFUL = {
-				  6673, -- Battle Shout
-				 97463, -- Rallying Cry
-				147833, -- Intervene (Protection)
-				223658, -- Safeguard (Protection talent)
+				   6673, -- Battle Shout
+				 147833, -- Intervene (Protection)
+				 223658, -- Safeguard (Protection talent)
+				[ 97463] = "SURVIVAL", -- Rallying Cry
 			},
 			HARMFUL = {
 				  1160, -- Demoralizing Shout (Protection)
-				105771, -- Charge (Protection/Fury)
 				113344, -- Bloodbath (Fury talent)
 				115804, -- Mortal Wounds (Arms)
 				208086, -- Colossus Smash (Arms)
 				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
-					[ 355] = "TAUNT", -- Taunt
-					[5246] = "DISORIENT", -- Intimidating Shout
+					[   355] = "TAUNT", -- Taunt
+					[  5246] = "DISORIENT", -- Intimidating Shout
+					[105771] = "ROOT", -- Charge
 					STUN = {
 						132168, -- Shockwave (Protection)
 						132169, -- Storm Bolt (talent)
 					},
 				},
 				SNARE = {
-					 1715, -- Hamstring (Arms)
-					 6343, -- Thunderclap (Protection)
-					12323, -- Piercing Howl (Fury)
+					  1715, -- Hamstring (Arms)
+					 12323, -- Piercing Howl (Fury)
+					[ 6343] = "POWER_REGEN", -- Thunder Clap (Protection)
 				},
 			},
 			PERSONAL = {
@@ -73,9 +73,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				260708, -- Sweeping Strikes (Arms)
 				274818, -- Bloodbath (Fury talent)
 				BURST = {
-					  1719, -- Recklessness (Fury)
-					107574, -- Avatar (Protection)(Fury/Arms talent)
-					262228, -- Deadly Calm (Arms talent)
+					   1719, -- Recklessness (Fury)
+					 262228, -- Deadly Calm (Arms talent)
+					[107574] = "POWER_REGEN", -- Avatar (Protection)(Fury/Arms talent)
 				},
 				SURVIVAL = {
 					   871, -- Shield Wall (Protection)
@@ -125,9 +125,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[ 52437] =  29725, -- Sudden Death (Arms talent)
 	[ 85739] = 190411, -- Meat Cleaver <- Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry
-	[105771] = { -- Charge (root)
+	[105771] = { -- Charge
 		   100, -- Charge (Fury/Arms)
-		198304, -- Intercept - Charge (Protection)
+		198304, -- Intercept (Protection)
 	},
 	[113344] =  12292, -- Bloodbath (Fury talent)
 	[115767] = 115768, -- Deep Wounds (Protection)
@@ -135,7 +135,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[132168] =  46968, -- Shockwave (Protection)
 	[132169] = 107570, -- Storm Bolt (talent)
 	[132404] =   2565, -- Shield Block (Protection)
-	[147833] = 198304, -- Intercept <- Intervene (Protection)
+	[147833] = 198304, -- Intervene (Protection) <- Intercept
 	[184362] = 184361, -- Enrage (Fury)
 	[197690] = 212520, -- Defensive Stance (Arms talent)
 	[202164] = 202163, -- Bounding Stride (talent)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -20,205 +20,74 @@ along with LibPlayerSpells-1.0.  If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
-lib:__RegisterSpells("WARRIOR", 70300, 1, {
+lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
-		   6544, -- Heroic Leap
-		 202168, -- Impending Victory
-		 209577, -- Warbreaker (Arms artifact)
-		[  6552] = "INTERRUPT", -- Pummel
+		 6544, -- Heroic Leap (Protection)
+		 6572, -- Revenge (Protection)
+		23922, -- Shield Slam (Protection)
+	       [ 6552] = "INTERRUPT", -- Pummel
 		AURA = {
-			PERSONAL = {
-				  12292, -- Bloodbath
-				  18499, -- Berserker Rage
-				  23920, -- Spell Reflection
-				  46924, -- Bladestorm (Fury)
-				 118000, -- Dragon Roar
-				 132404, -- Shield Block
-				 188783, -- Might of the Vrykul (Protection artifact)
-				 188923, -- Cleave
-				 202164, -- Bounding Stride
-				 202225, -- Furious Charge
-				 209484, -- Tactical Advance (Arms artifact)
-				 209706, -- Shattered Defenses (Arms artifact)
-				 227847, -- Bladestorm (Arms)
-				 248622, -- In for the Kill
-				BURST = {
-					  1719, -- Battle Cry
-					107574, -- Avatar
-				},
-				SURVIVAL = {
-					   871, -- Shield Wall
-					 12975, -- Last Stand
-					118038, -- Die by the Sword
-					184364, -- Enraged Regeneration
-					197690, -- Defensive Stance
-					203524, -- Neltharion's Fury (Protection artifact)
-					227744, -- Ravager
-				},
-			},
 			HELPFUL = {
-				 97463, -- Commanding Shout
-				223658, -- Safeguard
+				  6673, -- Battle Shout (Protection)
+				 97463, -- Rallying Cry (Protection)
+				147833, -- Intervene (Protection)
 			},
 			HARMFUL = {
-				   1160, -- Demoralizing Shout
-				 115804, -- Mortal Wounds
-				 205546, -- Odyn's Fury (Fury artifact)
-				 208086, -- Colossus Smash
-				 243016, -- Neltharions Thunder (Protection artifact)
-				[  6343] = "SNARE", -- Thunder Clap (slow)
-				[206891] = "UNIQUE_AURA", -- Intimidated (PvP)
+				  1160, -- Demoralizing Shout (Protection)
+				105771, -- Charge (Protection)
 				CROWD_CTRL = {
-					[ 355] = "TAUNT", -- Taunt (taunt)
-					[5246] = "DISORIENT", -- Intimidating Shout (disorient)
+					[5246] = "DISORIENT", -- Intimidating Shout (Protection)
 					STUN = {
-						  7922, -- Warbringer Stun (stun)
-						132168, -- Shockwave (stun)
-						132169, -- Storm Bolt (stun)
+						132168, -- Shockwave (Protection)
+					},
+					TAUNT = {
+						355, -- Taunt (Protection)
 					},
 				},
+				SNARE = {
+					6343, -- Thunderclap (Protection)
+				},
+
 			},
+			PERSONAL = {
+				 18499, -- Berserker Rage (Protection)
+				 23920, -- Spell Reflection (Protection)
+				132404, -- Shield Block (Protection)
+ 				BURST = {
+					107574, -- Avatar (Protection)
+				},
+				SURVIVAL = {
+					  871, -- Shield Wall (Protection)
+					12975, -- Last Stand (Protection)
+				},
+			},
+
 		},
 	},
 	AURA = {
-		HELPFUL = {
-			147833, -- Intervene
-		},
 		HARMFUL = {
-			   772, -- Rend
-			105771, -- Charge (root) -- TODO: no DR?
-			115767, -- Deep Wounds
-			215537, -- Trauma
-			242188, -- Executioner's Precision (Arms artifact)
-			SNARE = {
-				  1715, -- Hamstring (slow)
-				 12323, -- Piercing Howl (slow)
-				236027, -- Charge (slow)
-			},
+			115767, -- Deep Wounds (Protection)
 		},
 		PERSONAL = {
-			 32216, -- Victorious
-			 60503, -- Overpower!
-			 85739, -- Meat Cleaver
-			184362, -- Enrage
-			200979, -- Sense Death (Fury artifact)
-			201009, -- Juggernaut (Fury artifact)
-			202289, -- Renewed Fury
-			202539, -- Frenzy
-			202573, -- Vengeance: Revenge
-			202574, -- Vengeance: Ignore Pain
-			203581, -- Dragon Scales (Protection artifact)
-			206316, -- Massacre
-			206333, -- Taste for Blood
-			207982, -- Focused Rage (Arms)
-			215570, -- Wrecking Ball
+			32216, -- Victorious (Protection)
 			SURVIVAL = {
-				190456, -- Ignore Pain
+				190456, -- Ignore Pain (Protection)
 			},
 		},
 	},
 }, {
 	-- Map aura to provider(s)
-	[  7922] = 103828, -- Warbringer (stun)
-	[ 32216] = { -- Victorious
-		 34428, -- Victory Rush
-		202168, -- Impending Victory
-	},
-	[ 60503] = 7384, -- Overpower! <- Overpower
-	[ 85739] = 190411, -- Meat Cleaver <- Whirlwind (Fury)
-	[ 97463] = 97462, -- Commanding Shout
-	[105771] = { -- Charge (root)
-		   100, -- Charge
-		198304, -- Intercept
-	},
-	[115767] = 115768, -- Deep Wounds
-	[115804] = 12294, -- Mortal Wounds <- Mortal Strike
-	[132168] = 46968, -- Shockwave (stun)
-	[132169] = 107570, -- Storm Bolt (stun)
-	[132404] = 2565, -- Shield Block
-	[147833] = 198304, -- Intervene <- Intercept
-	[184362] = 184361, -- Enrage
-	[188783] = 188778, -- Might of the Vrykul (Protection artifact)
-	[188923] = 845, -- Cleave
-	[197690] = 212520, -- Defensive Stance
-	[200979] = 200863, -- Sense Death (Fury artifact)
-	[201009] = 200875, -- Juggernaut (Fury artifact)
-	[202164] = 202163, -- Bounding Stride
-	[202225] = 202224, -- Furious Charge
-	[202289] = 202288, -- Renewed Fury
-	[202539] = 206313, -- Frenzy
-	[202573] = 202572, -- Vengeance: Revenge <- Vengeance
-	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance
-	[203581] = 203576, -- Dragon Scales (Protection artifact)
-	[205546] = 205545, -- Odyn's Fury (Fury artifact)
-	[206316] = 206315, -- Massacre
-	[206333] = 100130, -- Taste for Blood <- Furious Slash
-	[206891] = 205800, -- Oppressor (Protection Honor Talent)
-	[208086] = { -- Colossus Smash
-		167105, -- Colossus Smash
-		209577, -- Warbreaker (Arms artifact)
-	},
-	[209484] = 209483, -- Tactical Advance (Arms artifact)
-	[209706] = 209574, -- Shattered Defenses (Arms artifact)
-	[215537] = 215538, -- Trauma
-	[215570] = 215569, -- Wrecking Ball
-	[227744] = 228920, -- Ravager
-	[223658] = 198304, -- Safeguard <- Intercept
-	[236027] = { -- Charge (slow)
-		   100, -- Charge
-		198304, -- Intercept
-	},
-	[242188] = 238147, -- Executioner's Precision (Arms artifact)
-	[243016] = 238149, -- Neltharions Thunder (Protection artifact)
-	[248622] = 248621, -- In for the Kill
+	[ 32216] =  34428, -- Victory Rush (Protection)
+	[ 97463] =  97462, -- Rallying Cry (Protection)
+	[105771] = 198304, -- Intercept - Charge (Protection)
+	[115767] = 115768, -- Deep Wounds (Protection)
+	[132168] =  46968, -- Shockwave (Protection)
+	[132404] =   2565, -- Shield Block (Protection)
+	[147833] = 198304, -- Intercept - Intervene (Protection)
 }, {
 	-- map aura to modified spell(s)
-	[  7922] = 198304, -- Warbringer (stun) -> Intercept
-	[ 85739] = { -- Meat Cleaver
-		 23881, -- Bloodthirst
-		184367, -- Rampage
+	[115767] = { -- Deep Wounds (Protection)
+		 6572, -- Revenge (Protection)
+		20243, -- Devestate (Protection)
 	},
-	[115767] = { -- Deep Wounds
-		  6572, -- Revenge
-		 20243, -- Devastate
-		236282, -- Devastator
-	},
-	[184362] = 85288, -- Enrage -> Raging Blow
-	[188783] = { -- Might of the Vrykul (Protection artifact)
-		 6343, -- Thunder Clap
-		23922, -- Shield Slam
-	},
-	[188923] = 1680, -- Cleave -> Whirlwind
-	[200979] = 5308, -- Sense Death (Fury artifact) -> Execute
-	[201009] = 5308, -- Juggernaut (Fury artifact) -> Execute
-	[202164] = 6544, -- Bounding Stride -> Heroic Leap
-	[202225] = 23881, -- Furious Charge -> Bloodthirst
-	[202289] = 190456, -- Renewed Fury -> Ignore Pain
-	[202539] = 100130, -- Frenzy -> Furious Slash
-	[202573] = 6572, -- Vengeance: Revenge -> Revenge
-	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain
-	[203581] = 190456, -- Dragon Scales (Protection artifact) -> Ignore Pain
-	[206316] = 184367, -- Massacre -> Rampage
-	[206333] = 23881, -- Taste for Blood -> Bloodthirst
-	[207982] = { -- Focused Rage (Arms)
-		 12294, -- Mortal Strike
-		207982, -- Focused Rage
-	},
-	[209484] = 6544, -- Tactical Advance -> Heroic Leap (Arms artifact)
-	[209706] = { -- Shattered Defenses (Arms artifact)
-		 12294, -- Mortal Strike
-		163201, -- Execute (Arms)
-	},
-	[215537] = { -- Trauma
-		  1464, -- Slam
-		  1680, -- Whirlwind
-		163201, -- Execute
-	},
-	[215570] = 190411, -- Wrecking Ball -> Whirlwind
-	[242188] = { -- Executioner's Precision (Arms artifact)
-		 12294, -- Mortal Strike (modified)
-		163201, -- Execute (Arms) (provider)
-	},
-	[243016] = 6343, -- Neltharions Thunder (Protection artifact) -> Thunder Clap
-	[248622] = 167105, -- In for the Kill -> Colossus Smash
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -18,144 +18,136 @@ You should have received a copy of the GNU General Public License
 along with LibPlayerSpells-1.0. If not, see <http://www.gnu.org/licenses/>.
 --]]
 
-local lib = LibStub("LibPlayerSpells-1.0")
+local lib = LibStub('LibPlayerSpells-1.0')
 if not lib then return end
-lib:__RegisterSpells("WARRIOR", 80000, 1, {
+lib:__RegisterSpells('WARRIOR', 80000, 1, {
 	COOLDOWN = {
-		    845, -- Cleave (Arms talent)
+			845, -- Cleave (Arms talent)
+		   5308, -- Execute (Fury)
 		   6544, -- Heroic Leap
-		   6572, -- Revenge (Protection)
 		  57755, -- Heroic Throw
 		 202168, -- Impending Victory (talent)
-		[  6552] = "INTERRUPT", -- Pummel
-		[206572] = "KNOCKBACK", -- Dragon Charge (Protection honor talent)
+		[  6552] = 'INTERRUPT', -- Pummel
+		[206572] = 'KNOCKBACK', -- Dragon Charge (Protection honor talent)
 		AURA = {
-			HELPFUL = {
-				 199038, -- Leave No Man Behind (Protection honor talent)
-				 206891, -- Intimidated (Protection honor talent)
-				 213871, -- Bodyguard (Protection honor talent)
-				 223658, -- Safeguard (Protection talent)
-				[  6673] = "RAIDBUFF", -- Battle Shout
-				[147833] = "POWER_REGEN", -- Intervene (Protection)
-				SURVIVAL = {
-					 97463, -- Rallying Cry
-					213915, -- Mass Spell Reflection (Protection honor talent)
-				},
-			},
 			HARMFUL = {
-				   1160, -- Demoralizing Shout (Protection)
-				 113344, -- Bloodbath (Fury talent)
 				 115804, -- Mortal Wounds (Arms)
 				 198819, -- Mortal Strike (Arms honor talent)
 				 198912, -- Shield Bash (Protection honor talent)
+				 206891, -- Intimidated (Protection honor talent)
 				 236077, -- Disarm (honor talent)
-				 236321, -- War Banner (Arms honor talent)
-				 236273, -- Duel (Arms honor talent) -- NOTE: also PERSONAL with the same id
-				 248622, -- In for the Kill (Arms talent)
+				 236273, -- Duel (Arms honor talent)
 				 275335, -- Punish (Protection talent)
-				[208086] = "BURST", -- Colossus Smash (Arms)
+				[  1160] = 'SURVIVAL', -- Demoralizing Shout (Protection)
+				BURST = {
+					208086, -- Colossus Smash (Arms)
+					280773, -- Siegebreaker (Fury talent)
+				},
 				CROWD_CTRL = {
-					[   355] = "TAUNT", -- Taunt
-					[  5246] = "DISORIENT", -- Intimidating Shout
+					[ 355] = 'TAUNT', -- Taunt
+					[5246] = 'DISORIENT', -- Intimidating Shout
 					ROOT = {
-						 199042, -- Thunderstruck (Protection honor talent)
-						[105771] = "POWER_REGEN", -- Charge
+						105771, -- Charge
+						199042, -- Thunderstruck (Protection honor talent)
 					},
 					STUN = {
 						132168, -- Shockwave (Protection)
 						132169, -- Storm Bolt (talent)
-						199085, -- Warpath (Protection honor talent)
+						199095, -- Warpath (Protection honor talent)
 					},
 				},
 				SNARE = {
-					[ 6343] = "POWER_REGEN", -- Thunder Clap (Protection)
+					  6343, -- Thunder Clap (Protection)
+					118000, -- Dragon Roar (Fury/Protection talent)
 				},
+			},
+			HELPFUL = {
+				  97463, -- Rallying Cry (Protection)
+				 147833, -- Intervene (Protection)
+				 199038, -- Leave No Man Behind (Protection honor talent)
+				 223658, -- Safeguard (Protection talent)
+				 236321, -- War Banner (Arms honor talent)
+				[213871] = 'SURVIVAL', -- Bodyguard (Protection honor talent)
 			},
 			PERSONAL = {
 				  7384, -- Overpower (Arms)
 				 18499, -- Berserker Rage
-				 23920, -- Spell Reflection (Protection)
 				 46924, -- Bladestorm (Fury talent)
-				 85739, -- Meat Cleaver (Fury)
-				132404, -- Shield Block (Protection)
-				198817, -- Sharpen Blade (Arms honor talen)
+				198817, -- Sharpen Blade (Arms honor talent)
+				199203, -- Thirst for Battle (Fury honor talent)
 				199261, -- Death Wish (Fury honor talent)
 				202164, -- Bounding Stride (talent)
 				202225, -- Furious Charge (Fury talent)
 				213858, -- Battle Trance (Fury honor talent)
-				216890, -- Spell Reflection (Arms/Fury honor talent)
+				215572, -- Frothing Berserker (Fury talent)
 				227847, -- Bladestorm (Arms)
+				248622, -- In For The Kill (Arms)
 				260708, -- Sweeping Strikes (Arms)
-				274818, -- Bloodbath (Fury talent)
+				280746, -- Barbarian (Fury honor talent)
 				BURST = {
-					   1719, -- Recklessness (Fury)
-					 118000, -- Dragon Roar (Fury talent)
-					 262228, -- Deadly Calm (Arms talent)
-					[107574] = "POWER_REGEN", -- Avatar (Protection)(Fury/Arms talent)
+					  1719, -- Recklessness (Fury)
+					107574, -- Avatar (Protection, Arms talent)
+					262228, -- Deadly Calm (Arms talent)
 				},
 				SURVIVAL = {
 					   871, -- Shield Wall (Protection)
 					 12975, -- Last Stand (Protection)
+					 23920, -- Spell Reflection (Protection)
 					118038, -- Die by the Sword (Arms)
+					132404, -- Shield Block (Protection)
 					184364, -- Enraged Regeneration (Fury)
+					190456, -- Ignore Pain (Protection)
 					197690, -- Defensive Stance (Arms talent)
+					213915, -- Mass Spell Reflection (Protection honor talent)
+					216890, -- Spell Reflection (Arms/Fury honor talent)
 					227744, -- Ravager (Protection talent)
-					275337, -- Bolster (Protection talent)
 				},
 			},
 		},
 		POWER_REGEN = {
 			 23881, -- Bloodthirst (Fury)
 			 23922, -- Shield Slam (Protection)
+			 85288, -- Raging Blow (Fury)
 			152277, -- Ravager (Arms talent)
 			260643, -- Skullsplitter (Arms talent)
-		}
+		},
 	},
 	AURA = {
 		HARMFUL = {
-			    772, -- Rend (Arms talent)
-			 115767, -- Deep Wounds (Protection)
-			 215537, -- Trauma (Arms talent)
-			 262115, -- Deep Wounds (Arms)
+			   772, -- Rend (Arms talent)
+			115767, -- Deep Wounds (Protection)
+			262115, -- Deep Wounds (Arms)
 			SNARE = {
 				 1715, -- Hamstring (Arms)
 				12323, -- Piercing Howl (Fury)
-			}
+			},
+		},
+		HELPFUL = {
+			[6673] = 'RAIDBUFF', -- Battle Shout
 		},
 		PERSONAL = {
-			 32216, -- Victorious
+			  5302, -- Revenge (Protection)
+			 32216, -- Victory Rush
 			 52437, -- Sudden Death (Arms talent)
+			 85739, -- Whirlwind (Fury)
 			184362, -- Enrage (Fury)
-			199203, -- Thirst for Battle (Fury honor talent)
-			202539, -- Frenzy (Fury talent)
+			202539, -- Furious Stash (Fury talent)
 			202573, -- Vengeance: Revenge (Protection talent)
 			202574, -- Vengeance: Ignore Pain (Protection talent)
-			202602, -- Into the Fray (Protection talent)
-			206316, -- Massacre (Fury talent)
-			206333, -- Taste for Blood (Fury)
-			215562, -- War Machine (Fury talent)
-			215570, -- Wrecking Ball (Fury talent)
-			215572, -- Frothing Berserker (Fury talent)
-			262232, -- War Machine (Arms talent)
-			SURVIVAL = {
-				190456, -- Ignore Pain (Protection)
-			},
+			280776, -- Suddeen Death (Fury talent)
 		},
 	},
 }, {
 	-- Map aura to provider(s)
-	[ 32216] = { -- Victorious
-		 34428, -- Victory Rush (Protection/Arms)
-		202168, -- Impending Victory (talent)
-	},
+	[  5302] =   6572, -- Revenge (Protection)
+	[ 32216] =  34428, -- Victory Rush
 	[ 52437] =  29725, -- Sudden Death (Arms talent)
-	[ 85739] = 190411, -- Meat Cleaver <- Whirlwind (Fury)
+	[ 85739] = 190411, -- Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry
 	[105771] = { -- Charge
-		   100, -- Charge (Fury/Arms)
+		   100, -- Charge (Arms/Fury)
 		198304, -- Intercept (Protection)
 	},
-	[113344] =  12292, -- Bloodbath (Fury talent)
 	[115767] = 115768, -- Deep Wounds (Protection)
 	[115804] =  12294, -- Mortal Wounds (Arms) <- Mortal Strike
 	[132168] =  46968, -- Shockwave (Protection)
@@ -163,82 +155,68 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intervene (Protection) <- Intercept
 	[184362] = 184361, -- Enrage (Fury)
-	[198819] = 198817, -- Mortal Strike (Arms honor talent) <- Sharpen Blade
+	[198819] = 198817, -- Mortal Strike <- Sharpen Blade (Arms honor talent)
 	[199038] = 199037, -- Leave No Man Behind (Protection honor talent)
 	[199042] = 199045, -- Thunderstruck (Protection honor talent)
-	[199085] = 199086, -- Warpath (Protection honor talent)
+	[199095] = 198096, -- Warpath (Protection honor talent)
 	[199203] = 199202, -- Thirst for Battle (Fury honor talent)
 	[202164] = 202163, -- Bounding Stride (talent)
 	[202225] = 202224, -- Furious Charge (Fury talent)
-	[202539] = 206313, -- Frenzy (Fury talent)
-	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protectiont talent)
+	[202539] = 100130, -- Furious Stash (Fury talent)
+	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protection talent)
 	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance (Protection talent)
-	[202602] = 202603, -- Into the Fray (Protection talent)
-	[206316] = 206315, -- Massacre (Fury talent)
-	[206333] = 100130, -- Taste for Blood <- Furious Slash
-	[206891] = 205800, -- Intimidated (Protection honor talent) <- Oppressor
+	[213858] = 213857, -- Battle Trance (Fury honor talent)
+	[215572] = 215571, -- Frothing Berserker (Fury talent)
+	[206891] = 205800, -- Intimidated (Protection honor talent)
 	[208086] = { -- Colossus Smash (Arms)
-		167105, -- Colossus Smash (Arms)
+		167105, -- Colossus Smash
 		262161, -- Warbreaker (Arms talent)
 	},
-	[213858] = 213857, -- Battle Trance (Fury honor talent)
-	[215537] = 215538, -- Trauma (Arms talent)
-	[215562] = 215556, -- War Machine (Fury talent)
-	[215570] = 215569, -- Wrecking Ball (Fury talent)
-	[215572] = 215571, -- Frothing Berserker (Fury talent)
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
 	[236321] = 236320, -- War Banner (Arms honor talent)
-	[248622] = 248621, -- In for the Kill (Arms talent)
+	[248622] = 248621, -- In For The Kill (Arms)
 	[262115] = 262111, -- Deep Wounds (Arms) <- Mastery: Deep Wounds
-	[262232] = 262231, -- War Machine (Arms talent)
-	[274818] =  12292, -- Bloodbath (Fury talent)
 	[275335] = 275334, -- Punish (Protection talent)
+	[280746] = 280745, -- Barbarian (Fury honor talent)
+	[280773] = 280772, -- Siegebreaker (Fury talent)
+	[280776] = 280721, -- Suddeen Death (Fury talent)
 }, {
 	-- map aura to modified spell(s)
-	[  7384] =  12294, -- Overpower -> Mortal Strike (Arms)
-	[ 52437] = 163201, -- Sudden Death (Arms talent) -> Execute
-	[ 85739] = { -- Meat Cleaver (Fury)
-		 23881, -- Bloodthirst (Fury)
-		184367, -- Rampage (Fury)
-	},
+	[  7384] =  12294, -- Overpower (Arms) -> Mortal Strike
+	[ 52437] = 163201, -- Sudden Death (Arms talent)
 	[115767] = { -- Deep Wounds (Protection)
-		  6572, -- Revenge (Protection)
-		 20243, -- Devestate (Protection)
-		236279, -- Devastator (Protection talent)
+		 6572, -- Revenge
+		20243, -- Devastate
 	},
-	[184362] =  85288, -- Enrage (Fury) -> Raging Blow
+	[184362] = { -- Enrage (Fury)
+		 23881, -- Bloodthirst
+		184367, -- Rampage
+	},
 	[197690] = 212520, -- Defensive Stance (Arms talent)
-	[198817] =  12294, -- Sharpen Blade (Arms honor talen) -> Mortal Strike
+	[198819] =  12294, -- Mortal Strike (Arms honor talent) -> Mortal Strike
 	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
 	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
-	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
+	[199095] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
 	[199203] =  23881, -- Thirst for Battle (Fury honor talent) -> Bloodthirst
 	[202164] =   6544, -- Bounding Stride (talent) -> Heroic Leap
 	[202225] =  23881, -- Furious Charge (Fury talent) -> Bloodthirst
-	[202539] = 100130, -- Frenzy (Fury talent) -> Furious Slash
-	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
+	[202573] =   6572, -- Vengeance: Revenge (Protection talent) -> Revenge
 	[202574] = 190456, -- Vengeance: Ignore Pain (Protection talent) -> Ignore Pain
-	[206316] = 184367, -- Massacre (Fury talent) -> Rampage
-	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
 	[213858] =  85288, -- Battle Trance (Fury honor talent) -> Raging Blow
-	[215537] = { -- Trauma (Arms talent)
-		  1464, -- Slam (Arms)
-		  1680, -- Whirlwind (Arms)
-		163201, -- Execute (Arms)
-	},
-	[215570] = 190411, -- Wrecking Ball -> Whirlwind (Fury talent)
+	[215572] = 184367, -- Frothing Berserker (Fury talent) -> Rampage
 	[223658] = 198304, -- Safeguard (Protection talent) -> Intercept
-	[248622] = { -- In for the Kill (Arms talent)
+	[248622] = { -- In For The Kill (Arms)
 		167105, -- Colossus Smash
 		262161, -- Warbreaker (Arms talent)
 	},
 	[262115] = { -- Deep Wounds (Arms) <- Mastery: Deep Wounds
-	       845, -- Cleave (Arms talent)
+		   845, -- Cleave (Arms talent)
 		 12294, -- Mortal Strike
-		152277, -- Ravager (Arms talent)
 		163201, -- Execute
 		227847, -- Bladestorm
 	},
-	[275335] =  23922, -- Punish (Protection talent) -> Shield Slam
+	[275335] =  23922, -- Punish (Protection talent)
+	[280746] =   6544, -- Barbarian (Fury honor talent) -> Heroic Leap
+	[280776] =   5308, -- Suddeen Death (Fury talent) -> Execute
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -26,6 +26,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		   6544, -- Heroic Leap
 		   6572, -- Revenge (Protection)
 		  23881, -- Bloodthirst (Fury)
+		  57755, -- Heroic Throw
 		 152277, -- Ravager (Arms talent)
 		 202168, -- Impending Victory (talent)
 		 260643, -- Skullsplitter (Arms talent)
@@ -46,12 +47,12 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				},
 			},
 			HARMFUL = {
-				  1160, -- Demoralizing Shout (Protection)
-				113344, -- Bloodbath (Fury talent)
-				115804, -- Mortal Wounds (Arms)
-				198912, -- Shield Bash (Protection honor talent)
-				208086, -- Colossus Smash (Arms)
-				275335, -- Punish (Protection talent)
+				   1160, -- Demoralizing Shout (Protection)
+				 113344, -- Bloodbath (Fury talent)
+				 115804, -- Mortal Wounds (Arms)
+				 198912, -- Shield Bash (Protection honor talent)
+				 275335, -- Punish (Protection talent)
+				[208086] = "BURST", -- Colossus Smash (Arms)
 				CROWD_CTRL = {
 					[   355] = "TAUNT", -- Taunt
 					[  5246] = "DISORIENT", -- Intimidating Shout
@@ -66,7 +67,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 					},
 				},
 				SNARE = {
-					  1715, -- Hamstring (Arms)
 					 12323, -- Piercing Howl (Fury)
 					[ 6343] = "POWER_REGEN", -- Thunder Clap (Protection)
 				},
@@ -102,11 +102,12 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 	AURA = {
 		HARMFUL = {
-			   772, -- Rend (Arms talent)
-			115767, -- Deep Wounds (Protection)
-			215537, -- Trauma (Arms talent)
-			248622, -- In for the Kill (Arms talent)
-			262115, -- Deep Wounds (Arms)
+			    772, -- Rend (Arms talent)
+			 115767, -- Deep Wounds (Protection)
+			 215537, -- Trauma (Arms talent)
+			 248622, -- In for the Kill (Arms talent)
+			 262115, -- Deep Wounds (Arms)
+			[  1715] = "SNARE", -- Hamstring (Arms)
 		},
 		PERSONAL = {
 			 32216, -- Victorious
@@ -143,7 +144,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 	[113344] =  12292, -- Bloodbath (Fury talent)
 	[115767] = 115768, -- Deep Wounds (Protection)
-	[115804] =  12294, -- Mortal Strike (Arms
+	[115804] =  12294, -- Mortal Wounds (Arms) <- Mortal Strike
 	[132168] =  46968, -- Shockwave (Protection)
 	[132169] = 107570, -- Storm Bolt (talent)
 	[132404] =   2565, -- Shield Block (Protection)
@@ -173,10 +174,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
 	[248622] = 248621, -- In for the Kill (Arms talent)
-	[262115] = { -- Deep Wounds (Arms)
-		   845, -- Cleave (Arms talent)
-		262111, -- Mastery: Deep Wounds (Arms)
-	},
+	[262115] = 262111, -- Deep Wounds (Arms) <- Mastery: Deep Wounds
 	[262232] = 262231, -- War Machine (Arms talent)
 	[274818] =  12292, -- Bloodbath (Fury talent)
 	[275335] = 275334, -- Punish (Protection talent)
@@ -214,6 +212,12 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[248622] = {
 		167105, -- In for the Kill -> Colossus Smash (Arms talent)
 		262161, -- In for the Kill -> Warbreaker (Arms talent)
+	},
+	[262115] = { -- Deep Wounds (Arms) <- Mastery: Deep Wounds
+	       845, -- Cleave (Arms talent)
+		 12294, -- Mortal Strike
+		163201, -- Execute
+		227847, -- Bladestorm
 	},
 	[275335] =  23922, -- Punish (Protection talent) -> Shield Slam
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -27,7 +27,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		   6572, -- Revenge (Protection)
 		  23881, -- Bloodthirst (Fury)
 		  57755, -- Heroic Throw
-		 152277, -- Ravager (Arms talent)
 		 202168, -- Impending Victory (talent)
 		[  6552] = "INTERRUPT", -- Pummel
 		[206572] = "KNOCKBACK", -- Dragon Charge (Protection honor talent)
@@ -48,7 +47,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				   1160, -- Demoralizing Shout (Protection)
 				 113344, -- Bloodbath (Fury talent)
 				 115804, -- Mortal Wounds (Arms)
+				 198819, -- Mortal Strike (Arms honor talent)
 				 198912, -- Shield Bash (Protection honor talent)
+				 236321, -- War Banner (Arms honor talent)
+				 236273, -- Duel (Arms honor talent) -- NOTE: also PERSONAL with the same id
 				 248622, -- In for the Kill (Arms talent)
 				 275335, -- Punish (Protection talent)
 				[208086] = "BURST", -- Colossus Smash (Arms)
@@ -78,8 +80,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 85739, -- Meat Cleaver (Fury)
 				118000, -- Dragon Roar (fury talent)
 				132404, -- Shield Block (Protection)
+				198817, -- Sharpen Blade (Arms honor talen)
 				202164, -- Bounding Stride (talent)
 				202225, -- Furious Charge (Fury talent)
+				216890, -- Spell Reflection (Arms/Fury honor talent)
 				227847, -- Bladestorm (Arms)
 				260708, -- Sweeping Strikes (Arms)
 				274818, -- Bloodbath (Fury talent)
@@ -101,6 +105,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		},
 		POWER_REGEN = {
 			 23922, -- Shield Slam (Protection)
+			152277, -- Ravager (Arms talent)
 			260643, -- Skullsplitter (Arms talent)
 		}
 	},
@@ -152,6 +157,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intervene (Protection) <- Intercept
 	[184362] = 184361, -- Enrage (Fury)
+	[198819] = 198817, -- Mortal Strike (Arms honor talent) <- Sharpen Blade
 	[199038] = 199037, -- Leave No Man Behind (Protection honor talent)
 	[199042] = 199045, -- Thunderstruck (Protection honor talent)
 	[199085] = 199086, -- Warpath (Protection honor talent)
@@ -174,6 +180,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[215572] = 215571, -- Frothing Berserker (Fury talent)
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
+	[236321] = 236320, -- War Banner (Arms honor talent)
 	[248622] = 248621, -- In for the Kill (Arms talent)
 	[262115] = 262111, -- Deep Wounds (Arms) <- Mastery: Deep Wounds
 	[262232] = 262231, -- War Machine (Arms talent)
@@ -194,6 +201,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
 	[197690] = 212520, -- Defensive Stance (Arms talent)
+	[198817] =  12294, -- Sharpen Blade (Arms honor talen) -> Mortal Strike
 	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
 	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
 	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -29,9 +29,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		  57755, -- Heroic Throw
 		 152277, -- Ravager (Arms talent)
 		 202168, -- Impending Victory (talent)
-		 260643, -- Skullsplitter (Arms talent)
 		[  6552] = "INTERRUPT", -- Pummel
-		[ 23922] = "POWER_REGEN", -- Shield Slam (Protection)
 		[206572] = "KNOCKBACK", -- Dragon Charge (Protection honor talent)
 		AURA = {
 			HELPFUL = {
@@ -51,6 +49,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 113344, -- Bloodbath (Fury talent)
 				 115804, -- Mortal Wounds (Arms)
 				 198912, -- Shield Bash (Protection honor talent)
+				 248622, -- In for the Kill (Arms talent)
 				 275335, -- Punish (Protection talent)
 				[208086] = "BURST", -- Colossus Smash (Arms)
 				CROWD_CTRL = {
@@ -94,18 +93,22 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 					 12975, -- Last Stand (Protection)
 					118038, -- Die by the Sword (Arms)
 					184364, -- Enraged Regeneration (Fury)
+					197690, -- Defensive Stance (Arms talent)
 					227744, -- Ravager (Protection talent)
 					275337, -- Bolster (Protection talent)
 				},
 			},
 		},
+		POWER_REGEN = {
+			 23922, -- Shield Slam (Protection)
+			260643, -- Skullsplitter (Arms talent)
+		}
 	},
 	AURA = {
 		HARMFUL = {
 			    772, -- Rend (Arms talent)
 			 115767, -- Deep Wounds (Protection)
 			 215537, -- Trauma (Arms talent)
-			 248622, -- In for the Kill (Arms talent)
 			 262115, -- Deep Wounds (Arms)
 			[  1715] = "SNARE", -- Hamstring (Arms)
 		},
@@ -125,7 +128,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			262232, -- War Machine (Arms talent)
 			SURVIVAL = {
 				190456, -- Ignore Pain (Protection)
-				197690, -- Defensive Stance (Arms talent)
 			},
 		},
 	},
@@ -150,7 +152,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intervene (Protection) <- Intercept
 	[184362] = 184361, -- Enrage (Fury)
-	[197690] = 212520, -- Defensive Stance (Arms talent)
 	[199038] = 199037, -- Leave No Man Behind (Protection honor talent)
 	[199042] = 199045, -- Thunderstruck (Protection honor talent)
 	[199085] = 199086, -- Warpath (Protection honor talent)
@@ -181,7 +182,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 }, {
 	-- map aura to modified spell(s)
 	[  7384] =  12294, -- Overpower -> Mortal Strike (Arms)
-	[ 52437] = 163201, -- Sudden Death -> Execute (Arms talent)
+	[ 52437] = 163201, -- Sudden Death (Arms talent) -> Execute
 	[ 85739] = { -- Meat Cleaver (Fury)
 		 23881, -- Bloodthirst (Fury)
 		184367, -- Rampage (Fury)
@@ -192,6 +193,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		236279, -- Devastator (Protection talent)
 	},
 	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
+	[197690] = 212520, -- Defensive Stance (Arms talent)
 	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
 	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
 	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
@@ -209,13 +211,14 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 	[215570] = 190411, -- Wrecking Ball -> Whirlwind (Fury talent)
 	[223658] = 198304, -- Safeguard (Protection talent) -> Intercept
-	[248622] = {
-		167105, -- In for the Kill -> Colossus Smash (Arms talent)
-		262161, -- In for the Kill -> Warbreaker (Arms talent)
+	[248622] = { -- In for the Kill (Arms talent)
+		167105, -- Colossus Smash
+		262161, -- Warbreaker (Arms talent)
 	},
 	[262115] = { -- Deep Wounds (Arms) <- Mastery: Deep Wounds
 	       845, -- Cleave (Arms talent)
 		 12294, -- Mortal Strike
+		152277, -- Ravager (Arms talent)
 		163201, -- Execute
 		227847, -- Bladestorm
 	},

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -31,26 +31,38 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		 260643, -- Skullsplitter (Arms talent)
 		[  6552] = "INTERRUPT", -- Pummel
 		[ 23922] = "POWER_REGEN", -- Shield Slam (Protection)
+		[206572] = "KNOCKBACK", -- Dragon Charge (Protection honor talent)
 		AURA = {
 			HELPFUL = {
-				 147833, -- Intervene (Protection)
+				 199038, -- Leave No Man Behind (Protection honor talent)
+				 206891, -- Intimidated (Protection honor talent)
+				 213871, -- Bodyguard (Protection honor talent)
 				 223658, -- Safeguard (Protection talent)
 				[  6673] = "RAIDBUFF", -- Battle Shout
-				[ 97463] = "SURVIVAL", -- Rallying Cry
+				[147833] = "POWER_REGEN", -- Intervene (Protection)
+				SURVIVAL = {
+					 97463, -- Rallying Cry
+					213915, -- Mass Spell Reflection (Protection honor talent)
+				},
 			},
 			HARMFUL = {
 				  1160, -- Demoralizing Shout (Protection)
 				113344, -- Bloodbath (Fury talent)
 				115804, -- Mortal Wounds (Arms)
+				198912, -- Shield Bash (Protection honor talent)
 				208086, -- Colossus Smash (Arms)
 				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
 					[   355] = "TAUNT", -- Taunt
 					[  5246] = "DISORIENT", -- Intimidating Shout
-					[105771] = "ROOT", -- Charge
+					ROOT = {
+						 199042, -- Thunderstruck (Protection honor talent)
+						[105771] = "POWER_REGEN", -- Charge
+					},
 					STUN = {
 						132168, -- Shockwave (Protection)
 						132169, -- Storm Bolt (talent)
+						199085, -- Warpath (Protection honor talent)
 					},
 				},
 				SNARE = {
@@ -138,6 +150,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[147833] = 198304, -- Intervene (Protection) <- Intercept
 	[184362] = 184361, -- Enrage (Fury)
 	[197690] = 212520, -- Defensive Stance (Arms talent)
+	[199038] = 199037, -- Leave No Man Behind (Protection honor talent)
+	[199042] = 199045, -- Thunderstruck (Protection honor talent)
+	[199085] = 199086, -- Warpath (Protection honor talent)
 	[202164] = 202163, -- Bounding Stride (talent)
 	[202225] = 202224, -- Furious Charge (Fury talent)
 	[202539] = 206313, -- Frenzy (Fury talent)
@@ -146,6 +161,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202602] = 202603, -- Into the Fray (Protection talent)
 	[206316] = 206315, -- Massacre (Fury talent)
 	[206333] = 100130, -- Taste for Blood <- Furious Slash
+	[206891] = 205800, -- Intimidated (Protection honor talent) <- Oppressor
 	[208086] = { -- Colossus Smash (Arms)
 		167105, -- Colossus Smash (Arms)
 		262161, -- Warbreaker (Arms talent)
@@ -178,6 +194,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		236279, -- Devastator (Protection talent)
 	},
 	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
+	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
+	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
+	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
 	[202164] =   6544, -- Bounding Stride -> Heroic Leap (talent)
 	[202225] =  23881, -- Furious Charge -> Bloodthirst (Fury talent)
 	[202539] = 100130, -- Frenzy -> Furious Slash (Fury talent)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -22,7 +22,7 @@ local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
 lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
-		  6544, -- Heroic Leap (Protection/Fury)
+		  6544, -- Heroic Leap
 		  6572, -- Revenge (Protection)
 		 23881, -- Bloodthirst (Fury)
 		 23922, -- Shield Slam (Protection)
@@ -30,8 +30,8 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	       [  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
-				  6673, -- Battle Shout (Protection/Fury)
-				 97463, -- Rallying Cry (Protection/Fury)
+				  6673, -- Battle Shout
+				 97463, -- Rallying Cry
 				147833, -- Intervene (Protection)
 				223658, -- Safeguard (Protection talent)
 			},
@@ -39,22 +39,26 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				  1160, -- Demoralizing Shout (Protection)
 				105771, -- Charge (Protection/Fury)
 				113344, -- Bloodbath (Fury talent)
+				115804, -- Mortal Wounds (Arms)
+				208086, -- Colossus Smash (Arms)
 				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
 					[ 355] = "TAUNT", -- Taunt
-					[5246] = "DISORIENT", -- Intimidating Shout (Protection/Fury)
+					[5246] = "DISORIENT", -- Intimidating Shout
 					STUN = {
 						132168, -- Shockwave (Protection)
 						132169, -- Storm Bolt (Protection/Fury talent)
 					},
 				},
 				SNARE = {
+					 1715, -- Hamstring (Arms)
 					 6343, -- Thunderclap (Protection)
 					12323, -- Piercing Howl (Fury)
 				},
 			},
 			PERSONAL = {
-				 18499, -- Berserker Rage (Protection/Fury)
+				  7384, -- Overpower (Arms)
+				 18499, -- Berserker Rage
 				 23920, -- Spell Reflection (Protection)
 				 46924, -- Bladestorm (Fury talent)
 				 85739, -- Meat Cleaver (Fury)
@@ -62,6 +66,8 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				132404, -- Shield Block (Protection)
 				202164, -- Bounding Stride (Protection/Fury talent)
 				202225, -- Furious Charge (Fury talent)
+				227847, -- Bladestorm (Arms)
+				260708, -- Sweeping Strikes (Arms)
 				274818, -- Bloodbath (Fury talent)
  				BURST = {
 					  1719, -- Recklessness (Fury)
@@ -70,6 +76,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				SURVIVAL = {
 					   871, -- Shield Wall (Protection)
 					 12975, -- Last Stand (Protection)
+					118038, -- Die by the Sword (Arms)
 					184364, -- Enraged Regeneration (Fury)
 					227744, -- Ravager (Protection talent)
 					275337, -- Bolster (Protection talent)
@@ -80,9 +87,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	AURA = {
 		HARMFUL = {
 			115767, -- Deep Wounds (Protection)
+			262115, -- Deep Wounds (Arms)
 		},
 		PERSONAL = {
-			 32216, -- Victorious (Protection)
+			 32216, -- Victorious
 			184362, -- Enrage (Fury)
 			202539, -- Frenzy (Fury talent)
 			202573, -- Vengeance: Revenge (Protection talent)
@@ -100,18 +108,19 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 }, {
 	-- Map aura to provider(s)
-	[ 32216] = { -- Victorious (Protection)
-		 34428, -- Victory Rush (Protection)
+	[ 32216] = { -- Victorious
+		 34428, -- Victory Rush (Protection/Arms)
 		202168, -- Impending Victory (Protection/Fury talent)
 	},
 	[ 85739] = 190411, -- Meat Cleaver -> Whirlwind (Fury)
-	[ 97463] =  97462, -- Rallying Cry (Protection)
+	[ 97463] =  97462, -- Rallying Cry
 	[105771] = { -- Charge (root)
-		   100, -- Charge (Fury)
+		   100, -- Charge (Fury/Arms)
 		198304, -- Intercept - Charge (Protection)
 	},
 	[113344] =  12292, -- Bloodbath (Fury talent)
 	[115767] = 115768, -- Deep Wounds (Protection)
+	[115804] =  12294, -- Mortal Strike (Arms
 	[132168] =  46968, -- Shockwave (Protection)
 	[132169] = 107570, -- Storm Bolt (Protection/Fury talent)
 	[132404] =   2565, -- Shield Block (Protection)
@@ -125,15 +134,18 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202602] = 202603, -- Into the Fray (Protection talent)
 	[206316] = 206315, -- Massacre (Fury talent)
 	[206333] = 100130, -- Taste for Blood -> Furious Slash
+	[208086] = 167105, -- Colossus Smash (Arms)
 	[215562] = 215556, -- War Machine (Fury talent)
 	[215570] = 215569, -- Wrecking Ball (Fury talent)
 	[215572] = 215571, -- Frothing Berserker (Fury talent)
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
+	[262115] = 262111, -- Mastery: Deep Wounds (Arms)
 	[274818] =  12292, -- Bloodbath (Fury talent)
 	[275335] = 275334, -- Punish (Protection talent)
 }, {
 	-- map aura to modified spell(s)
+	[  7384] = 12294, -- Overpower -> Mortal Strike (Arms)
 	[ 85739] = { -- Meat Cleaver (Fury)
 		 23881, -- Bloodthirst (Fury)
 		184367, -- Rampage (Fury)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -48,6 +48,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 115804, -- Mortal Wounds (Arms)
 				 198819, -- Mortal Strike (Arms honor talent)
 				 198912, -- Shield Bash (Protection honor talent)
+				 236077, -- Disarm (honor talent)
 				 236321, -- War Banner (Arms honor talent)
 				 236273, -- Duel (Arms honor talent) -- NOTE: also PERSONAL with the same id
 				 248622, -- In for the Kill (Arms talent)
@@ -78,8 +79,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 85739, -- Meat Cleaver (Fury)
 				132404, -- Shield Block (Protection)
 				198817, -- Sharpen Blade (Arms honor talen)
+				199261, -- Death Wish (Fury honor talent)
 				202164, -- Bounding Stride (talent)
 				202225, -- Furious Charge (Fury talent)
+				213858, -- Battle Trance (Fury honor talent)
 				216890, -- Spell Reflection (Arms/Fury honor talent)
 				227847, -- Bladestorm (Arms)
 				260708, -- Sweeping Strikes (Arms)
@@ -123,6 +126,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			 32216, -- Victorious
 			 52437, -- Sudden Death (Arms talent)
 			184362, -- Enrage (Fury)
+			199203, -- Thirst for Battle (Fury honor talent)
 			202539, -- Frenzy (Fury talent)
 			202573, -- Vengeance: Revenge (Protection talent)
 			202574, -- Vengeance: Ignore Pain (Protection talent)
@@ -163,6 +167,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[199038] = 199037, -- Leave No Man Behind (Protection honor talent)
 	[199042] = 199045, -- Thunderstruck (Protection honor talent)
 	[199085] = 199086, -- Warpath (Protection honor talent)
+	[199203] = 199202, -- Thirst for Battle (Fury honor talent)
 	[202164] = 202163, -- Bounding Stride (talent)
 	[202225] = 202224, -- Furious Charge (Fury talent)
 	[202539] = 206313, -- Frenzy (Fury talent)
@@ -176,6 +181,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		167105, -- Colossus Smash (Arms)
 		262161, -- Warbreaker (Arms talent)
 	},
+	[213858] = 213857, -- Battle Trance (Fury honor talent)
 	[215537] = 215538, -- Trauma (Arms talent)
 	[215562] = 215556, -- War Machine (Fury talent)
 	[215570] = 215569, -- Wrecking Ball (Fury talent)
@@ -201,12 +207,13 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		 20243, -- Devestate (Protection)
 		236279, -- Devastator (Protection talent)
 	},
-	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
+	[184362] =  85288, -- Enrage (Fury) -> Raging Blow
 	[197690] = 212520, -- Defensive Stance (Arms talent)
 	[198817] =  12294, -- Sharpen Blade (Arms honor talen) -> Mortal Strike
 	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
 	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
 	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
+	[199203] =  23881, -- Thirst for Battle (Fury honor talent) -> Bloodthirst
 	[202164] =   6544, -- Bounding Stride (talent) -> Heroic Leap
 	[202225] =  23881, -- Furious Charge (Fury talent) -> Bloodthirst
 	[202539] = 100130, -- Frenzy (Fury talent) -> Furious Slash
@@ -214,6 +221,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202574] = 190456, -- Vengeance: Ignore Pain (Protection talent) -> Ignore Pain
 	[206316] = 184367, -- Massacre (Fury talent) -> Rampage
 	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
+	[213858] =  85288, -- Battle Trance (Fury honor talent) -> Raging Blow
 	[215537] = { -- Trauma (Arms talent)
 		  1464, -- Slam (Arms)
 		  1680, -- Whirlwind (Arms)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -76,7 +76,6 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 23920, -- Spell Reflection (Protection)
 				 46924, -- Bladestorm (Fury talent)
 				 85739, -- Meat Cleaver (Fury)
-				118000, -- Dragon Roar (fury talent)
 				132404, -- Shield Block (Protection)
 				198817, -- Sharpen Blade (Arms honor talen)
 				202164, -- Bounding Stride (talent)
@@ -87,6 +86,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				274818, -- Bloodbath (Fury talent)
 				BURST = {
 					   1719, -- Recklessness (Fury)
+					 118000, -- Dragon Roar (Fury talent)
 					 262228, -- Deadly Calm (Arms talent)
 					[107574] = "POWER_REGEN", -- Avatar (Protection)(Fury/Arms talent)
 				},
@@ -207,12 +207,12 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[199038] = 198304, -- Leave No Man Behind (Protection honor talent) -> Intercept
 	[199042] =   6343, -- Thunderstruck (Protection honor talent) -> Thunder Clap
 	[199085] =   6544, -- Warpath (Protection honor talent) -> Heroic Leap
-	[202164] =   6544, -- Bounding Stride -> Heroic Leap (talent)
-	[202225] =  23881, -- Furious Charge -> Bloodthirst (Fury talent)
-	[202539] = 100130, -- Frenzy -> Furious Slash (Fury talent)
+	[202164] =   6544, -- Bounding Stride (talent) -> Heroic Leap
+	[202225] =  23881, -- Furious Charge (Fury talent) -> Bloodthirst
+	[202539] = 100130, -- Frenzy (Fury talent) -> Furious Slash
 	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
 	[202574] = 190456, -- Vengeance: Ignore Pain (Protection talent) -> Ignore Pain
-	[206316] = 184367, -- Massacre -> Rampage (Fury talent)
+	[206316] = 184367, -- Massacre (Fury talent) -> Rampage
 	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
 	[215537] = { -- Trauma (Arms talent)
 		  1464, -- Slam (Arms)

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -33,9 +33,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		[ 23922] = "POWER_REGEN", -- Shield Slam (Protection)
 		AURA = {
 			HELPFUL = {
-				   6673, -- Battle Shout
 				 147833, -- Intervene (Protection)
 				 223658, -- Safeguard (Protection talent)
+				[  6673] = "RAIDBUFF", -- Battle Shout
 				[ 97463] = "SURVIVAL", -- Rallying Cry
 			},
 			HARMFUL = {

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -182,7 +182,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202225] =  23881, -- Furious Charge -> Bloodthirst (Fury talent)
 	[202539] = 100130, -- Frenzy -> Furious Slash (Fury talent)
 	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
-	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain (Protection talent)
+	[202574] = 190456, -- Vengeance: Ignore Pain (Protection talent) -> Ignore Pain
 	[206316] = 184367, -- Massacre -> Rampage (Fury talent)
 	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
 	[215537] = { -- Trauma (Arms talent)
@@ -191,10 +191,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		163201, -- Execute (Arms)
 	},
 	[215570] = 190411, -- Wrecking Ball -> Whirlwind (Fury talent)
-	[223658] = 198304, -- Safeguard -> Intercept (Protection talent)
+	[223658] = 198304, -- Safeguard (Protection talent) -> Intercept
 	[248622] = {
 		167105, -- In for the Kill -> Colossus Smash (Arms talent)
 		262161, -- In for the Kill -> Warbreaker (Arms talent)
 	},
-	[275335] =  23922, -- Punish -> Shield Slam (Protection talent)
+	[275335] =  23922, -- Punish (Protection talent) -> Shield Slam
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -22,49 +22,54 @@ local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
 lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
-		  6544, -- Heroic Leap (Protection)
+		  6544, -- Heroic Leap (Protection/Fury)
 		  6572, -- Revenge (Protection)
+		 23881, -- Bloodthirst (Fury)
 		 23922, -- Shield Slam (Protection)
 		202168, -- Impending Victory (Protection talent)
 	       [  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
-				  6673, -- Battle Shout (Protection)
-				 97463, -- Rallying Cry (Protection)
+				  6673, -- Battle Shout (Protection/Fury)
+				 97463, -- Rallying Cry (Protection/Fury)
 				147833, -- Intervene (Protection)
 				223658, -- Safeguard (Protection talent)
 			},
 			HARMFUL = {
 				  1160, -- Demoralizing Shout (Protection)
-				105771, -- Charge (Protection)
+				105771, -- Charge (Protection/Fury)
 				275335, -- Punish (Protection talent)
 				CROWD_CTRL = {
-					[5246] = "DISORIENT", -- Intimidating Shout (Protection)
+					[5246] = "DISORIENT", -- Intimidating Shout (Protection/Fury)
 					STUN = {
 						132168, -- Shockwave (Protection)
 						132169, -- Storm Bolt (Protection talent)
 					},
 					TAUNT = {
-						355, -- Taunt (Protection)
+						355, -- Taunt (Protection/Fury)
 					},
 				},
 				SNARE = {
-					6343, -- Thunder Clap (Protection)
+					 6343, -- Thunderclap (Protection)
+					12323, -- Piercing Howl (Fury)
 				},
 			},
 			PERSONAL = {
-				 18499, -- Berserker Rage (Protection)
+				 18499, -- Berserker Rage (Protection/Fury)
 				 23920, -- Spell Reflection (Protection)
+				 85739, -- Meat Cleaver (Fury)
 				132404, -- Shield Block (Protection)
 				202164, -- Bounding Stride (Protection talent)
 				227744, -- Ravager (Protection talent)
 				275337, -- Bolster (Protection talent)
  				BURST = {
+					  1719, -- Recklessness (Fury)
 					107574, -- Avatar (Protection)
 				},
 				SURVIVAL = {
-					  871, -- Shield Wall (Protection)
-					12975, -- Last Stand (Protection)
+					   871, -- Shield Wall (Protection)
+					 12975, -- Last Stand (Protection)
+					184364, -- Enraged Regeneration (Fury)
 				},
 			},
 		},
@@ -75,9 +80,11 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		},
 		PERSONAL = {
 			 32216, -- Victorious (Protection)
+			184362, -- Enrage (Fury)
 			202573, -- Vengeance: Revenge (Protection talent)
 			202574, -- Vengeance: Ignore Pain (Protection talent)
 			202602, -- Into the Fray (Protection talent)
+			206333, -- Taste for Blood (Fury)
 			SURVIVAL = {
 				190456, -- Ignore Pain (Protection)
 			},
@@ -89,30 +96,42 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		 34428, -- Victory Rush (Protection)
 		202168, -- Impending Victory (Protection talent)
 	},
+	[ 85739] = 190411, -- Meat Cleaver -> Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry (Protection)
-	[105771] = 198304, -- Intercept - Charge (Protection)
+	[105771] = { -- Charge (root)
+		   100, -- Charge (Fury)
+		198304, -- Intercept - Charge (Protection)
+	},
 	[115767] = 115768, -- Deep Wounds (Protection)
 	[132168] =  46968, -- Shockwave (Protection)
 	[132169] = 107570, -- Storm Bolt (Protection talent)
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intercept - Intervene (Protection)
+	[184362] = 184361, -- Enrage (Fury)
 	[202164] = 202163, -- Bounding Stride (Protection talent)
 	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protectiont talent)
 	[202574] = 202572, -- Vengeance: Ignore Pain <- Vengeance (Protection talent)
 	[202602] = 202603, -- Into the Fray (Protection talent)
+	[206333] = 100130, -- Taste for Blood -> Furious Slash
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
 	[275335] = 275334, -- Punish (Protection talent)
 }, {
 	-- map aura to modified spell(s)
+	[ 85739] = { -- Meat Cleaver (Fury)
+		 23881, -- Bloodthirst (Fury)
+		184367, -- Rampage (Fury)
+	},
 	[115767] = { -- Deep Wounds (Protection)
 		  6572, -- Revenge (Protection)
 		 20243, -- Devestate (Protection)
 		236279, -- Devastator (Protection talent)
 	},
+	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
 	[202164] =   6544, -- Bounding Stride -> Heroic Leap (Protection talent)
 	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
 	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain (Protection talent)
+	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
 	[223658] = 198304, -- Safeguard -> Intercept (Protection talent)
 	[275335] =  23922, -- Punish -> Shield Slam (Protection talent)
 })

--- a/data/Warrior.lua
+++ b/data/Warrior.lua
@@ -22,11 +22,14 @@ local lib = LibStub("LibPlayerSpells-1.0")
 if not lib then return end
 lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	COOLDOWN = {
+		   845, -- Cleave (Arms talent)
 		  6544, -- Heroic Leap
 		  6572, -- Revenge (Protection)
 		 23881, -- Bloodthirst (Fury)
 		 23922, -- Shield Slam (Protection)
-		202168, -- Impending Victory (Protection/Fury talent)
+		152277, -- Ravager (Arms talent)
+		202168, -- Impending Victory (talent)
+		260643, -- Skullsplitter (Arms talent)
 	       [  6552] = "INTERRUPT", -- Pummel
 		AURA = {
 			HELPFUL = {
@@ -47,7 +50,7 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 					[5246] = "DISORIENT", -- Intimidating Shout
 					STUN = {
 						132168, -- Shockwave (Protection)
-						132169, -- Storm Bolt (Protection/Fury talent)
+						132169, -- Storm Bolt (talent)
 					},
 				},
 				SNARE = {
@@ -64,14 +67,15 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 				 85739, -- Meat Cleaver (Fury)
 				118000, -- Dragon Roar (fury talent)
 				132404, -- Shield Block (Protection)
-				202164, -- Bounding Stride (Protection/Fury talent)
+				202164, -- Bounding Stride (talent)
 				202225, -- Furious Charge (Fury talent)
 				227847, -- Bladestorm (Arms)
 				260708, -- Sweeping Strikes (Arms)
 				274818, -- Bloodbath (Fury talent)
  				BURST = {
 					  1719, -- Recklessness (Fury)
-					107574, -- Avatar (Protection)(Fury talent)
+					107574, -- Avatar (Protection)(Fury/Arms talent)
+					262228, -- Deadly Calm (Arms talent)
 				},
 				SURVIVAL = {
 					   871, -- Shield Wall (Protection)
@@ -86,11 +90,15 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	},
 	AURA = {
 		HARMFUL = {
+			   772, -- Rend (Arms talent)
 			115767, -- Deep Wounds (Protection)
+			215537, -- Trauma (Arms talent)
+			248622, -- In for the Kill (Arms talent)
 			262115, -- Deep Wounds (Arms)
 		},
 		PERSONAL = {
 			 32216, -- Victorious
+			 52437, -- Sudden Death (Arms talent)
 			184362, -- Enrage (Fury)
 			202539, -- Frenzy (Fury talent)
 			202573, -- Vengeance: Revenge (Protection talent)
@@ -101,8 +109,10 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 			215562, -- War Machine (Fury talent)
 			215570, -- Wrecking Ball (Fury talent)
 			215572, -- Frothing Berserker (Fury talent)
+			262232, -- War Machine (Arms talent)
 			SURVIVAL = {
 				190456, -- Ignore Pain (Protection)
+				197690, -- Defensive Stance (Arms talent)
 			},
 		},
 	},
@@ -110,8 +120,9 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	-- Map aura to provider(s)
 	[ 32216] = { -- Victorious
 		 34428, -- Victory Rush (Protection/Arms)
-		202168, -- Impending Victory (Protection/Fury talent)
+		202168, -- Impending Victory (talent)
 	},
+	[ 52437] =  29725, -- Sudden Death (Arms talent)
 	[ 85739] = 190411, -- Meat Cleaver -> Whirlwind (Fury)
 	[ 97463] =  97462, -- Rallying Cry
 	[105771] = { -- Charge (root)
@@ -122,11 +133,12 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[115767] = 115768, -- Deep Wounds (Protection)
 	[115804] =  12294, -- Mortal Strike (Arms
 	[132168] =  46968, -- Shockwave (Protection)
-	[132169] = 107570, -- Storm Bolt (Protection/Fury talent)
+	[132169] = 107570, -- Storm Bolt (talent)
 	[132404] =   2565, -- Shield Block (Protection)
 	[147833] = 198304, -- Intercept - Intervene (Protection)
 	[184362] = 184361, -- Enrage (Fury)
-	[202164] = 202163, -- Bounding Stride (Protection/Fury talent)
+	[197690] = 212520, -- Defensive Stance (Arms talent)
+	[202164] = 202163, -- Bounding Stride (talent)
 	[202225] = 202224, -- Furious Charge (Fury talent)
 	[202539] = 206313, -- Frenzy (Fury talent)
 	[202573] = 202572, -- Vengeance: Revenge <- Vengeance (Protectiont talent)
@@ -134,18 +146,28 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 	[202602] = 202603, -- Into the Fray (Protection talent)
 	[206316] = 206315, -- Massacre (Fury talent)
 	[206333] = 100130, -- Taste for Blood -> Furious Slash
-	[208086] = 167105, -- Colossus Smash (Arms)
+	[208086] = { -- Colossus Smash (Arms)
+		167105, -- Colossus Smash (Arms)
+		262161, -- Warbreaker (Arms talent)
+	},
+	[215537] = 215538, -- Trauma (Arms talent)
 	[215562] = 215556, -- War Machine (Fury talent)
 	[215570] = 215569, -- Wrecking Ball (Fury talent)
 	[215572] = 215571, -- Frothing Berserker (Fury talent)
 	[223658] = 223657, -- Safeguard (Protection talent)
 	[227744] = 228920, -- Ravager (Protection talent)
-	[262115] = 262111, -- Mastery: Deep Wounds (Arms)
+	[248622] = 248621, -- In for the Kill (Arms talent)
+	[262115] = { -- Deep Wounds (Arms)
+		   845, -- Cleave (Arms talent)
+		262111, -- Mastery: Deep Wounds (Arms)
+	},
+	[262232] = 262231, -- War Machine (Arms talent)
 	[274818] =  12292, -- Bloodbath (Fury talent)
 	[275335] = 275334, -- Punish (Protection talent)
 }, {
 	-- map aura to modified spell(s)
-	[  7384] = 12294, -- Overpower -> Mortal Strike (Arms)
+	[  7384] =  12294, -- Overpower -> Mortal Strike (Arms)
+	[ 52437] = 163201, -- Sudden Death -> Execute (Arms talent)
 	[ 85739] = { -- Meat Cleaver (Fury)
 		 23881, -- Bloodthirst (Fury)
 		184367, -- Rampage (Fury)
@@ -156,14 +178,23 @@ lib:__RegisterSpells("WARRIOR", 80000, 1, {
 		236279, -- Devastator (Protection talent)
 	},
 	[184362] =  85288, -- Enrage -> Raging Blow (Fury)
-	[202164] =   6544, -- Bounding Stride -> Heroic Leap (Protection/Fury talent)
+	[202164] =   6544, -- Bounding Stride -> Heroic Leap (talent)
 	[202225] =  23881, -- Furious Charge -> Bloodthirst (Fury talent)
 	[202539] = 100130, -- Frenzy -> Furious Slash (Fury talent)
 	[202573] =   6572, -- Vengeance: Revenge -> Revenge (Protection talent)
 	[202574] = 190456, -- Vengeance: Ignore Pain -> Ignore Pain (Protection talent)
 	[206316] = 184367, -- Massacre -> Rampage (Fury talent)
 	[206333] =  23881, -- Taste for Blood -> Bloodthirst (Fury)
+	[215537] = { -- Trauma (Arms talent)
+		  1464, -- Slam (Arms)
+		  1680, -- Whirlwind (Arms)
+		163201, -- Execute (Arms)
+	},
 	[215570] = 190411, -- Wrecking Ball -> Whirlwind (Fury talent)
 	[223658] = 198304, -- Safeguard -> Intercept (Protection talent)
+	[248622] = {
+		167105, -- In for the Kill -> Colossus Smash (Arms talent)
+		262161, -- In for the Kill -> Warbreaker (Arms talent)
+	},
 	[275335] =  23922, -- Punish -> Shield Slam (Protection talent)
 })


### PR DESCRIPTION
**TO REVIEW** in the coming beta patches:
Protection:
- Vengeance talent: currently Shield Block (and not Ignore Pain) buffs Revenge.
- Intercept does not apply a snare on enemies

EDIT: In the latest build, revenge now reduces rage on Ignore Pain, but the buff is not consumed on using Ignore Pain.  Ignore Pain does not reduce the rage of Revenge.  

Still no snare from charge, and intercept stops short of melee.