### PR TITLE
All Spec Shaman. Blood DK. 9.0 PvE Updates.

### DIFF
--- a/data/Deathknight.lua
+++ b/data/Deathknight.lua
@@ -20,45 +20,46 @@ along with LibPlayerSpells-1.0. If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub('LibPlayerSpells-1.0')
 if not lib then return end
-lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
+lib:__RegisterSpells('DEATHKNIGHT', 90001, 1, {
 	COOLDOWN = {
-		  46584, -- Raise Dead (Unholy)
-		  49206, -- Summon Gargoyle (Unholy talent)
+		  46585, -- Raise Dead
+		  46584, -- Raise Dead (Rank 2 - Unholy)
+		  49206, -- Summon Gargoyle (Unholy Talent)
 		  49576, -- Death Grip
 		  50977, -- Death Gate
 		  61999, -- Raise Ally
-		 194913, -- Glacial Advance (Frost talent)
-		 210764, -- Rune Strike (Blood talent)
-		 274156, -- Consumption (Blood talent)
+		 194913, -- Glacial Advance (Frost Talent)
+		 221699, -- Blood Tap (Blood Talent)
+		 274156, -- Consumption (Blood Talent)
 		 275699, -- Apocalypse (Unholy)
-		 288853, -- Raise Abomination (Unholy honor talent)
+		 288853, -- Raise Abomination (Unholy PvP Talent)
 		[ 47528] = 'INTERRUPT', -- Mind Freeze
 		[108199] = 'KNOCKBACK', -- Gorefiend's Grasp (Blood)
 		AURA = {
 			HARMFUL = {
-				 47476, -- Strangulate (Blood honor talent) -- NOTE: Silence
+				 47476, -- Strangulate (Blood PvP Talent) -- NOTE: Silence
 				 55078, -- Blood Plague (Blood)
-				 77606, -- Dark Simulacrum (Blood/Unholy honor talent)
-				115994, -- Unholy Blight (Unholy talent)
-				130736, -- Soul Reaper (Unholy talent)
-				203173, -- Death Chain (Blood honor talent)
-				206891, -- Focused Assault (Blood honor talent)
-				206931, -- Blooddrinker (Blood talent)
-				206940, -- Mark of Blood (Blood talent)
-				211794, -- Winter is Comming (Frost talent)
-				212610, -- Walking Dead (Blood honor talent)
-				288849, -- Crypt Fever (Unholy honor talent)
+				 77606, -- Dark Simulacrum (Blood/Unholy PvP Talent)
+				115994, -- Unholy Blight (Unholy Talent)
+				130736, -- Soul Reaper (Unholy Talent)
+				203173, -- Death Chain (Blood PvP Talent)
+				206891, -- Focused Assault (Blood PvP Talent)
+				206931, -- Blooddrinker (Blood Talent)
+				206940, -- Mark of Blood (Blood Talent)
+				211794, -- Winter is Comming (Frost Talent)
+				212610, -- Walking Dead (Blood PvP Talent)
+				288849, -- Crypt Fever (Unholy PvP Talent)
 				CROWD_CTRL = {
-					[207167] = 'DISORIENT', -- Blinding Sleet (Frost talent)
+					[207167] = 'DISORIENT', -- Blinding Sleet (Frost Talent)
 					ROOT = {
 						 91807, -- Shambling Rush (Ghoul) (Unholy)
 					},
 					STUN = {
 						 91797, -- Monstrous Blow (Ghoul) (Unholy)
 						 91800, -- Gnaw (Ghoul) (Unholy)
-						108194, -- Asphyxiate (Unholy talent)
+						108194, -- Asphyxiate (Unholy Talent)
 						221562, -- Asphyxiate (Blood)
-						287254, -- Dead of Winter (Frost honor talent)
+						287254, -- Dead of Winter (Frost PvP Talent)
 					},
 					TAUNT = {
 						51399, -- Death Grip (Blood)
@@ -66,49 +67,49 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 					}
 				},
 				SNARE = {
-					204206, -- Chilled (Frost honor talent)
+					204206, -- Chilled (Frost PvP Talent)
 					206930, -- Heart Strike (Blood)
 					211793, -- Remorsless Winter (Frost)
-					273977, -- Grip of the Dead (Blood talent)
-					279303, -- Frost Breath (Frost talent)
+					273977, -- Grip of the Dead (Blood Talent)
+					279303, -- Frost Breath (Frost Talent)
 				},
 			},
 			HELPFUL = {
-				[145622] = 'SURVIVAL', -- Anti-Magic Zone (honor talent)
+				[145629] = 'SURVIVAL', -- Anti-Magic Zone
 			},
 			PERSONAL = {
 				  48265, -- Death's Advance
 				  77535, -- Blood Shield (Blood)
-				 115989, -- Unholy Blight (Unholy talent)
-				 152279, -- Breath of Sindragosa (Frost talent)
+				 115989, -- Unholy Blight (Unholy Talent)
+				 152279, -- Breath of Sindragosa (Frost Talent)
 				 188290, -- Death and Decay (Blood/Unholy)
-				 194844, -- Bonestorm (Blood talent)
+				 194844, -- Bonestorm (Blood Talent)
 				 195181, -- Bone Shield (Blood)
 				 196770, -- Remorseless Winter (Frost)
-				 212552, -- Wraith Walk (talent)
-				 215711, -- Soul Ripper (Unholy talent)
-				 219788, -- Ossuary (Blood talent)
-				 273947, -- Hemostasis (Blood talent)
-				 274009, -- Voracious (Blood talent)
-				[ 48743] = 'INVERT_AURA', -- Death Pact (Unholy talent)
+				 212552, -- Wraith Walk (Talent)
+				 215711, -- Soul Ripper (Unholy Talent)
+				 219788, -- Ossuary (Blood Talent)
+				 273947, -- Hemostasis (Blood Talent)
+				 274009, -- Voracious (Blood Talent)
+				[ 48743] = 'INVERT_AURA', -- Death Pact
 				BURST = {
 					 42650, -- Army of the Dead (Unholy)
 					 51271, -- Pillar of Frost (Frost)
-					207256, -- Obliteration (Frost talent)
-					207289, -- Unholy Frenzy (Unholy talent)
+					207256, -- Obliteration (Frost Talent)
+					207289, -- Unholy Frenzy (Unholy Talent)
 				},
 				POWER_REGEN = {
 					 47568, -- Empower Rune Weapon (Frost)
-					219809, -- Tombstone (Blood talent)
-					288977, -- Transfusion (Frost/Unholy honor talent)
+					219809, -- Tombstone (Blood Talent)
+					288977, -- Transfusion (Frost/Unholy PvP Talent)
 				},
 				SURVIVAL = {
 					 48707, -- Anti-Magic Shell
 					 48792, -- Icebound Fortitude
 					 55233, -- Vampiric Blood (Blood)
 					 81256, -- Dancing Rune Weapon (Blood)
-					194679, -- Rune Tap (Blood talent)
-					287081, -- Lichborne (Frost/Unholy honor talent)
+					194679, -- Rune Tap (Blood)
+					 49039, -- Lichborne
 				},
 			},
 			PET = {
@@ -120,8 +121,8 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 			},
 		},
 		POWER_REGEN = {
-			 57330, -- Horn of Winter (Frost talent)
-			207127, -- Hungering Rune Weapon (Frost talent)
+			 57330, -- Horn of Winter (Frost Talent)
+			207127, -- Hungering Rune Weapon (Frost Talent)
 		}
 	},
 	AURA = {
@@ -130,17 +131,17 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 			191587, -- Virulent Plague (Unholy)
 			194310, -- Festering Wound (Unholy)
 			196782, -- Outbreak (Unholy)
-			223929, -- Necrotic Wound (Unholy honor talent)
-			233397, -- Delirium (Frost honor talent)
+			223929, -- Necrotic Wound (Unholy PvP Talent)
+			233397, -- Delirium (Frost PvP Talent)
 			CROWD_CTRL = {
-				[204085] = 'ROOT', -- Deathchill (Frost honor talent)
+				[204085] = 'ROOT', -- Deathchill (Frost PvP Talent)
 				STUN = {
-					207165, -- Abomination's Might (Frost talent)
-					210141, -- Zombie Explosion (Unholy honor talent)
+					207165, -- Abomination's Might (Frost Talent)
+					210141, -- Zombie Explosion (Unholy PvP Talent)
 				},
 			},
 			SNARE = {
-				 45524, -- Chains of Ice (Frost/Unholy)
+				 45524, -- Chains of Ice
 			},
 		},
 		HELPFUL = {
@@ -152,12 +153,12 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 			 81141, -- Crimson Scourge (Blood)
 			 81340, -- Sudden Doom (Unholy)
 			101568, -- Dark Succor (Frost/Unholy)
-			194879, -- Icy Talons (Frost talent)
-			207203, -- Frost Shield (Frost talent)
-			233411, -- Blood for Blood (Blood honor talent)
-			253595, -- Inexorable Assault (Frost talent)
-			279942, -- Tundra Stalker (Frost honor talent)
-			281209, -- Cold Heart (Frost talent)
+			194879, -- Icy Talons (Frost Talent)
+			207203, -- Frost Shield (Frost Talent)
+			233411, -- Blood for Blood (Blood PvP Talent)
+			253595, -- Inexorable Assault (Frost Talent)
+			279942, -- Tundra Stalker (Frost PvP Talent)
+			281209, -- Cold Heart (Frost Talent)
 		},
 		PET = {
 			[111673] = 'INVERT_AURA', -- Control Undead
@@ -183,44 +184,44 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 	[ 91837] =  63560, -- Putrid Bulwark (Ghoul) (Unholy) <- Dark Transformation
 	[ 91838] =  47484, -- Huddle (Ghoul) (Unholy)
 	[101568] = 178819, -- Dark Succor (Frost/Unholy)
-	[145622] =  51052, -- Anti-Magic Zone (honor talent)
-	[115994] = 115989, -- Unholy Blight (Unholy talent)
+	[145629] =  51052, -- Anti-Magic Zone
+	[115994] = 115989, -- Unholy Blight (Unholy Talent)
 	[188290] = { -- Death and Decay (Blood/Unholy)
 		 43265, -- Death and Decay (Blood/Unholy)
-		152280, -- Defile (Unholy talent)
+		152280, -- Defile (Unholy Talent)
 	},
 	[191587] =  77575, -- Virulent Plague (Unholy) <- Outbreak
 	[194310] =  85948, -- Festering Wound (Unholy) <- Festering Strike
-	[194879] = 194878, -- Icy Talons (Frost talent)
+	[194879] = 194878, -- Icy Talons (Frost Talent)
 	[195181] = 195182, -- Bone Shield (Blood) <- Marrowrend
-	[204085] = 204080, -- Deathchill (Frost honor talent)
+	[204085] = 204080, -- Deathchill (Frost PvP Talent)
 	[211793] = 196770, -- Remorsless Winter (Frost)
 	[196782] =  77575, -- Outbreak (Unholy)
-	[204206] = 204160, -- Chilled (Frost honor talent) <- Chill Streak
-	[206891] = 207018, -- Focused Assault <- Murderous Intent (Blood honor talent)
-	[207165] = 207161, -- Abomination's Might (Frost talent)
-	[207203] = 207200, -- Frost Shield <- Permafrost (Frost talent)
-	[210141] = 210128, -- Zombie Explosion <- Reanimation (Unholy honor talent)
-	[211794] = 207170, -- Winter is Comming (Frost talent)
-	[212610] = 202731, -- Walking Dead (Blood honor talent)
-	[215711] = 130736, -- Soul Ripper (Unholy talent)
-	[219788] = 219786, -- Ossuary (Blood talent)
-	[223929] = 223829, -- Necrotic Wound (Unholy honor talent)
-	[233397] = 233396, -- Delirium (Frost honor talent)
-	[253595] = 253593, -- Inexorable Assault (Frost talent)
-	[273947] = 273946, -- Hemostasis (Blood talent)
-	[273977] = 273952, -- Grip of the Dead (Blood talent)
-	[274009] = 273953, -- Voracious (Blood talent)
-	[279303] = 279302, -- Frost Breath <- Frostwyrm's Fury (Frost talent)
-	[279942] = 279941, -- Tundra Stalker (Frost honor talent)
-	[281209] = 281208, -- Cold Heart (Frost talent)
-	[287254] = 287250, -- Dead of Winter (Frost honor talent)
-	[288849] = 288848, -- Crypt Fever <- Necromancer's Bargain (Unholy honor talent)
+	[204206] = 204160, -- Chilled (Frost PvP Talent) <- Chill Streak
+	[206891] = 207018, -- Focused Assault <- Murderous Intent (Blood PvP Talent)
+	[207165] = 207161, -- Abomination's Might (Frost Talent)
+	[207203] = 207200, -- Frost Shield <- Permafrost (Frost Talent)
+	[210141] = 210128, -- Zombie Explosion <- Reanimation (Unholy PvP Talent)
+	[211794] = 207170, -- Winter is Comming (Frost Talent)
+	[212610] = 202731, -- Walking Dead (Blood PvP Talent)
+	[215711] = 130736, -- Soul Ripper (Unholy Talent)
+	[219788] = 219786, -- Ossuary (Blood Talent)
+	[223929] = 223829, -- Necrotic Wound (Unholy PvP Talent)
+	[233397] = 233396, -- Delirium (Frost PvP Talent)
+	[253595] = 253593, -- Inexorable Assault (Frost Talent)
+	[273947] = 273946, -- Hemostasis (Blood Talent)
+	[273977] = 273952, -- Grip of the Dead (Blood Talent)
+	[274009] = 273953, -- Voracious (Blood Talent)
+	[279303] = 279302, -- Frost Breath <- Frostwyrm's Fury (Frost Talent)
+	[279942] = 279941, -- Tundra Stalker (Frost PvP Talent)
+	[281209] = 281208, -- Cold Heart (Frost Talent)
+	[287254] = 287250, -- Dead of Winter (Frost PvP Talent)
+	[288849] = 288848, -- Crypt Fever <- Necromancer's Bargain (Unholy PvP Talent)
 }, {
 	-- map aura to modified spell(s)
 	[ 51124] = { -- Killing Machine (Frost)
 		 49020, -- Obliterate
-		207230, -- Frostscythe (Frost talent)
+		207230, -- Frostscythe (Frost Talent)
 	},
 	[ 51399] =  49576, -- Death Grip (Blood)
 	[ 59052] =  49184, -- Rime (Frost) -> Howling Blast
@@ -231,32 +232,32 @@ lib:__RegisterSpells('DEATHKNIGHT', 80100, 1, {
 	[ 91807] =  47482, -- Shambling Rush (Ghoul) (Unholy) <- Leap (Ghoul)
 	[ 91837] =  47484, -- Putrid Bulwark (Ghoul) (Unholy) <- Huddle (Ghoul)
 	[101568] =  49998, -- Dark Succor (Frost/Unholy) -> Death Strike
-	[194879] =  { -- Icy Talons (Frost talent)
+	[194879] =  { -- Icy Talons (Frost Talent)
 		 49143, -- Frost Strike
 		 49998, -- Death Strike
-		152279, -- Breath of Sindragosa (Frost talent)
-		194913, -- Glacial Advance (Frost talent)
+		152279, -- Breath of Sindragosa (Frost Talent)
+		194913, -- Glacial Advance (Frost Talent)
 	},
-	[200646] =  77575, -- Unholy Mutation (Unholy honor talent) -> Outbreak
-	[207165] =  49020, -- Abomination's Might (Frost talent) -> Obliterate
-	[207203] =   6603, -- Frost Shield (Frost talent) -> Auto Attack
-	[204085] = { -- Deathchill (Frost honor talent)
+	[200646] =  77575, -- Unholy Mutation (Unholy PvP Talent) -> Outbreak
+	[207165] =  49020, -- Abomination's Might (Frost Talent) -> Obliterate
+	[207203] =   6603, -- Frost Shield (Frost Talent) -> Auto Attack
+	[204085] = { -- Deathchill (Frost PvP Talent)
 		 45524, -- Chains of Ice
 		196770, -- Remorseless Winter
 	},
-	[211794] = 196170, -- Winter is Comming (Frost talent) -> Remorseless Winter
-	[212610] =  49576, -- Walking Dead (Blood honor talent) -> Death Grip
-	[219788] = 195182, -- Ossuary (Blood talent) -> Marrowrend
-	[233397] = { -- Delirium (Frost honor talent)
+	[211794] = 196170, -- Winter is Comming (Frost Talent) -> Remorseless Winter
+	[212610] =  49576, -- Walking Dead (Blood PvP Talent) -> Death Grip
+	[219788] = 195182, -- Ossuary (Blood Talent) -> Marrowrend
+	[233397] = { -- Delirium (Frost PvP Talent)
 		49143, -- Frost Strike
 		49184, -- Howling Blast
 	},
-	[253595] =   6603, -- Inexorable Assault (Frost talent) -> Auto Attack
-	[273947] =  49998, -- Hemostasis (Blood talent) -> Death Strike
-	[273977] =  43265, -- Grip of the Dead (Blood talent) -> Death and Decay
-	[274009] =  49998, -- Voracious (Blood talent) -> Death Strike
-	[279942] =  49143, -- Tundra Stalker (Frost honor talent) -> Frost Strike
-	[281209] =  45524, -- Cold Heart (Frost talent) -> Chains of Ice
-	[287254] = 196770, -- Dead of Winter (Frost honor talent) -> Remorseless Winter
-	[288849] = 275699, -- Crypt Fever (Unholy honor talent) -> Apocalypse
+	[253595] =   6603, -- Inexorable Assault (Frost Talent) -> Auto Attack
+	[273947] =  49998, -- Hemostasis (Blood Talent) -> Death Strike
+	[273977] =  43265, -- Grip of the Dead (Blood Talent) -> Death and Decay
+	[274009] =  49998, -- Voracious (Blood Talent) -> Death Strike
+	[279942] =  49143, -- Tundra Stalker (Frost PvP Talent) -> Frost Strike
+	[281209] =  45524, -- Cold Heart (Frost Talent) -> Chains of Ice
+	[287254] = 196770, -- Dead of Winter (Frost PvP Talent) -> Remorseless Winter
+	[288849] = 275699, -- Crypt Fever (Unholy PvP Talent) -> Apocalypse
 })

--- a/data/Shaman.lua
+++ b/data/Shaman.lua
@@ -20,58 +20,63 @@ along with LibPlayerSpells-1.0. If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub('LibPlayerSpells-1.0')
 if not lib then return end
-lib:__RegisterSpells('SHAMAN', 80000, 3, {
+lib:__RegisterSpells('SHAMAN', 90001, 1, {
 	COOLDOWN = {
 		   8143, -- Tremor Totem
 		  17364, -- Stormstrike (Enhancement)
 		  51505, -- Lava Burst (Elemental)
 		  51533, -- Feral Spirit (Enhancement)
-		 115356, -- Windstrike (Enhancement talent) NOTE: when Ascendance is active
-		 196884, -- Feral Lunge (Enhancement talent)
-		 197995, -- Wellspring (Restoration talent)
+		 115356, -- Windstrike (Enhancement Talent) NOTE: when Ascendance is active
+		 192222, -- Liquid Magma Totem (Elemental Talent)
+		 196884, -- Feral Lunge (Enhancement Talent)
+		 197995, -- Wellspring (Restoration Talent)
 		 198067, -- Fire Elemental (Elemental)
 		 198103, -- Earth Elemental
-		 207778, -- Downpour (Restoration talent)
+		 207778, -- Downpour (Restoration Talent)
+		 320746, -- Surge of Earth (Restoration Talent)
+		 333974, -- Fire Nova (Enhancement Talent)
+		 342243, -- Static Discharge (Elemental Talent)
 		[ 57994] = 'INTERRUPT', -- Wind Shear
-		[193786] = 'POWER_REGEN', -- Rockbiter (Enhancement)
 		AURA = {
 			HARMFUL = {
-				118297, -- Immolate (Fire Elemental) (Elemental talent)
-				157375, -- Eye of the Storm (Storm Elemental) (Elemental talent)
-				188089, -- Earthen Spike (Enhancement talent)
+				118297, -- Immolate (Fire Elemental) (Elemental Talent)
+				157375, -- Eye of the Storm (Storm Elemental) (Elemental Talent)
+				188089, -- Earthen Spike (Enhancement Talent)
 				188389, -- Flame Shock (Elemental)
 				188838, -- Flame Shock (Restoration)
-				208997, -- Counterstrike Totem (honor talent)
-				210927, -- Static Cling (Enhancement honor talent)
-				268429, -- Searing Assault (Enhancement talent)
-				271924, -- Molten Weapon (Enhancement talent)
+				208997, -- Counterstrike Totem (PvP Talent)
+				210927, -- Static Cling (Enhancement PvP Talent)
+				268429, -- Searing Assault (Enhancement Talent)
+				271924, -- Molten Weapon (Enhancement Talent)
 				CROWD_CTRL = {
-					[64695] = 'ROOT', -- Earthgrab (Restoration talent)
+					[64695] = 'ROOT', -- Earthgrab (Restoration Talent)
 					INCAPACITATE = {
 						 51514, -- Hex
-						197214, -- Sundering (Enhancement talent)
+						197214, -- Sundering (Enhancement Talent)
 					},
 					STUN = {
-						118345, -- Pulverize (Earth Elemental) (Elemental talent)
+						118345, -- Pulverize (Earth Elemental) (Elemental Talent)
 						118905, -- Static Charge
-						204437, -- Lightning Lasso (Elemental honor talent)
+						204437, -- Lightning Lasso (Elemental PvP Talent)
 					},
 				},
 				SNARE = {
 					   3600, -- Earthbind
-					 116947, -- Earthbind (Restoration talent)
+					 116947, -- Earthbind (Restoration Talent)
+					 342240, -- Ice Strike (Enhancement Talent)
 					[ 51490] = 'KNOCKBACK', -- Thunderstorm (Elemental)
 				},
 			},
 			HELPFUL = {
-				  8178, -- Grounding Totem Effect (honor talent)
+				  8178, -- Grounding Totem Effect (PvP Talent)
 				 61295, -- Riptide (Restoration)
-				192082, -- Wind Rush (talent)
-				201633, -- Earthen Wall (Restoraton talent)
-				204366, -- Thundercharge (Enhancement honor talent)
+				192082, -- Wind Rush (Talent)
+				201633, -- Earthen Wall (Restoraton Talent)
+				204366, -- Thundercharge (Enhancement PvP Talent)
+				320763, -- Mana Tide Totem (Restoration)
 				BURST = {
-					204361, -- Bloodlust (Enhancement honor talent)
-					208963, -- Skyfury Totem (honor talent)
+					204361, -- Bloodlust (Enhancement PvP Talent)
+					208963, -- Skyfury Totem (PvP Talent)
 				},
 				RAIDBUFF = {
 					 2825, -- Bloodlust (horde)
@@ -83,93 +88,88 @@ lib:__RegisterSpells('SHAMAN', 80000, 3, {
 				},
 				SURVIVAL = {
 					 98007, -- Spirit Link Totem (Restoration)
-					207498, -- Ancestral Protection (Restoration talent)
+					207498, -- Ancestral Protection Totem (Restoration Talent)
 				},
 			},
 			PERSONAL = {
 				 58875, -- Spirit Walk (Enhancement)
-				 73685, -- Unleash Life (Restoration talent)
+				 73685, -- Unleash Life (Restoration Talent)
 				 73920, -- Healing Rain (Restoration)
 				 77762, -- Lava Surge (Elemental/Restoration)
 				 79206, -- Spiritwalker's Grace (Restoration)
-				108281, -- Ancestral Guidance (Elemental talent)
-				118522, -- Elemental Blast: Crtical Strike (Elemental talent)
-				157504, -- Cloudburst Totem (Restoration talent)
-				173183, -- Elemental Blast: Haste (Elemental talent)
-				173184, -- Elemental Blast: Mastery (Elemental talent)
+				108281, -- Ancestral Guidance (Elemental Talent)
+				118522, -- Elemental Blast: Crtical Strike (Elemental Talent)
+				157504, -- Cloudburst Totem (Restoration Talent)
+				173183, -- Elemental Blast: Haste (Elemental Talent)
+				173184, -- Elemental Blast: Mastery (Elemental Talent)
 				187878, -- Crash Lightning (Enhancement)
 				194084, -- Flametongue (Enhancement)
 				198300, -- Gathering Storms (Enhancement)
-				202004, -- Landslide (Enhancement talent)
-				210714, -- Icefury (Elemental talent)
-				211400, -- Static Cling (Enhancement honor talent)
-				224125, -- Molten Weapon (Enhancement talent)
-				224127, -- Crackling Surge (Enhancement talent)
-				236502, -- Tidebringer (Restoration honor talent)
-				236746, -- Control of Lava (Elemental honor talent)
-				260734, -- Master of the Elements (Elemental talent)
-				263806, -- Wind Gust (Elemental talent)
+				210714, -- Icefury (Elemental Talent)
+				211400, -- Static Cling (Enhancement PvP Talent)
+				224125, -- Molten Weapon (Elemental Spirits - Enhancement Talent)
+				224127, -- Crackling Surge (Elemental Spirits - Enhancement Talent)
+				236502, -- Tidebringer (Restoration PvP Talent)
+				236746, -- Control of Lava (Elemental PvP Talent)
+				260734, -- Master of the Elements (Elemental Talent)
+				263806, -- Wind Gust (Elemental Talent)
+				320125, -- Echoing Shock (Elemental Talent)
 				BURST = {
-					114050, -- Ascendance (Elemental talent)
-					114051, -- Ascendance (Enhancement talent)
-					114052, -- Ascendance (Restoration talent)
-					191634, -- Stormkeeper (Elemental talent)
+					114050, -- Ascendance (Elemental Talent)
+					114051, -- Ascendance (Enhancement Talent)
+					114052, -- Ascendance (Restoration Talent)
+					191634, -- Stormkeeper (Elemental Talent)
 				},
 				SURVIVAL = {
 					108271, -- Astral Shift
-					118337, -- Harden Skin (Earth Elemental) (Elemental talent)
-					210918, -- Ethereal Form (Enhancement honor talent)
+					118337, -- Harden Skin (Earth Elemental) (Elemental Talent)
+					210918, -- Ethereal Form (Enhancement PvP Talent)
 				},
 			},
 			PET = {
-				157348, -- Call Lightning (Storm Elemental) (Elemental talent)
+				157348, -- Call Lightning (Storm Elemental) (Elemental Talent)
 			},
 		},
 	},
 	AURA = {
 		HARMFUL = {
-			206647, -- Electrocute (Restoration honor talent)
-			269808, -- Exposed Elements (Elemental talent)
+			206647, -- Electrocute (Restoration PvP Talent)
+			269808, -- Exposed Elements (Elemental Talent)
 			[182387] = 'KNOCKBACK', -- Earthquake (Elemental)
 			CROWD_CTRL = {
-				[204399] = 'STUN', -- Earthfury (Elemental honor talent)
+				[204399] = 'STUN', -- Earthfury (Elemental PvP Talent)
 			},
 			SNARE = {
 				147732, -- Frostbrand (Enhancement)
 				196840, -- Frost Shock (Elemental)
-				197385, -- Fury of Air (Enhancement talent)
+				197385, -- Fury of Air (Enhancement Talent)
 			},
 		},
 		HELPFUL = {
 			   546, -- Water Walking
-			   974, -- Earth Shield (talent)
-			204293, -- Spirit Link (Restoration honor talent)
-			207400, -- Ancestral Vigor (Restoration talent)
+			   974, -- Earth Shield (Talent)
+			204293, -- Spirit Link (Restoration PvP Talent)
+			207400, -- Ancestral Vigor (Restoration Talent)
+			327942, -- Windfury Totem
 		},
 		PERSONAL = {
 			  2645, -- Ghost Wolf
 			  6196, -- Far Sight
+			 52127, -- Water Shield
 			 53390, -- Tidal Waves (Restoration)
-			192106, -- Lightning Shield (Enhancement talent)
+			192106, -- Lightning Shield (Enhancement Talent)
 			196834, -- Frostbrand (Enhancement)
-			197211, -- Fury of Air (Enhancement talent)
+			197211, -- Fury of Air (Enhancement Talent)
 			201846, -- Stormbringer (Enhancement)
-			202192, -- Resonance Totem (Elemental talent)
-			204262, -- Spectral Recovery (honor talent)
-			210652, -- Storm Totem (Elemental talent)
-			210658, -- Ember Totem (Elemental talent)
-			210659, -- Tailwind Totem (Elemental talent)
-			215785, -- Hot Hand (Enhacement talent)
-			216251, -- Undulation (Restoration talent)
-			262397, -- Storm Totem (Enhancement talent)
-			262399, -- Ember Totem (Enhancement talent)
-			262400, -- Tailwind Totem (Enhancement talent)
-			262417, -- Resonance Totem (Enhancement talent)
-			262652, -- Forceful Winds (Enhancement talent)
-			273323, -- Lightning Shield Overcharge (Enhancement talent)
-			280815, -- Flash Flood (Restoration talent)
+			202192, -- Resonance Totem (Elemental Talent)
+			204262, -- Spectral Recovery (PvP Talent)
+			215785, -- Hot Hand (Enhancement Talent)
+			216251, -- Undulation (Restoration Talent)
+			262652, -- Forceful Winds (Enhancement Talent)
+			273323, -- Lightning Shield Overcharge (Enhancement Talent)
+			280815, -- Flash Flood (Restoration Talent)
 			SURVIVAL = {
-				260881, -- Spirit Wolf (talent)
+				260881, -- Spirit Wolf (Talent)
 			},
 		},
 	},
@@ -183,65 +183,58 @@ lib:__RegisterSpells('SHAMAN', 80000, 3, {
 }, {
 	-- map aura to provider(s)
 	[  3600] =   2484, -- Earthbind <- Earthbind Totem
-	[  8178] = 204336, -- Grounding Totem Effect (honor talent) <- Grounding Totem
+	[  8178] = 204336, -- Grounding Totem Effect (PvP Talent) <- Grounding Totem
 	[ 53390] =  51564, -- Tidal Waves (Restoration)
-	[ 64695] =  51485, -- Earthgrab <- Earthgrab Totem (Restoration talent)
+	[ 64695] =  51485, -- Earthgrab <- Earthgrab Totem (Restoration Talent)
 	[ 77762] =  77756, -- Lava Surge (Elemental/Restoration)
 	[ 98007] =  98008, -- Spirit Link Totem (Restoration)
-	[116947] =  51485, -- Earthbind <- Earthgrab Totem (Restoration talent)
-	[118297] = 117013, -- Immolate <- Primal Elementalist (Elemental talent)
-	[118337] = 117013, -- Harden Skin <- Primal Elementalist (Elemental talent)
-	[118345] = 117013, -- Pulverize <- Primal Elementalist (Elemental talent)
-	[118522] = 117014, -- Elemental Blast: Crtical Strike (Elemental totem) <- Elemental Blast (Elemental talent)
+	[116947] =  51485, -- Earthbind <- Earthgrab Totem (Restoration Talent)
+	[118297] = 117013, -- Immolate <- Primal Elementalist (Elemental Talent)
+	[118337] = 117013, -- Harden Skin <- Primal Elementalist (Elemental Talent)
+	[118345] = 117013, -- Pulverize <- Primal Elementalist (Elemental Talent)
+	[118522] = 117014, -- Elemental Blast: Crtical Strike (Elemental Totem) <- Elemental Blast (Elemental Talent)
 	[118905] = 192058, -- Static Charge <- Capacitor Totem
 	[147732] = 196834, -- Frostbrand (Enhancement)
-	[157348] = 117013, -- Call Lightning <- Primal Elementalist (Elemental talent)
-	[157375] = 117013, -- Eye of the Storm <- Primal Elementalist (Elemental talent)
-	[157504] = 157153, -- Cloudburst Totem (Restoration talent)
-	[173183] = 117014, -- Elemental Blast: Haste (Elemental totem) <- Elemental Blast (Elemental talent)
-	[173184] = 117014, -- Elemental Blast: Mastery (Elemental totem) <- Elemental Blast (Elemental talent)
+	[157348] = 117013, -- Call Lightning <- Primal Elementalist (Elemental Talent)
+	[157375] = 117013, -- Eye of the Storm <- Primal Elementalist (Elemental Talent)
+	[157504] = 157153, -- Cloudburst Totem (Restoration Talent)
+	[173183] = 117014, -- Elemental Blast: Haste (Elemental Totem) <- Elemental Blast (Elemental Talent)
+	[173184] = 117014, -- Elemental Blast: Mastery (Elemental Totem) <- Elemental Blast (Elemental Talent)
 	[182387] =  61882, -- Earthquake (Elemental)
 	[187878] = 187874, -- Crash Lightning (Enhancement)
-	[192082] = 192077, -- Wind Rush <- Wind Rush Totem (talent)
+	[192082] = 192077, -- Wind Rush <- Wind Rush Totem (Talent)
 	[194084] = 193796, -- Flametongue (Enhancement)
-	[197385] = 197211, -- Fury of Air (Enhancement talent)
+	[197385] = 197211, -- Fury of Air (Enhancement Talent)
 	[198300] = 187874, -- Gathering Storms <- Crash Lightning (Enhancement)
-	[201633] = 198838, -- Earthen Wall <- Earthen Wall Totem (Restoraton talent)
+	[201633] = 198838, -- Earthen Wall <- Earthen Wall Totem (Restoraton Talent)
 	[201846] = 201845, -- Stormbringer (Enhancement)
-	[202004] = 197992, -- Landslide (Enhancement talent)
-	[202192] = 210643, -- Resonance Totem <- Totem Mastery (Elemental talent)
-	[204262] = 204261, -- Spectral Recovery (honor talent)
-	[204361] = 193876, -- Bloodlust <- Shamanism (Enhancement honor talent)
-	[204399] = 204398, -- Earthfury (Elemental honor talent)
-	[206647] = 206642, -- Electrocute (Restoration honor talent)
-	[207400] = 207401, -- Ancestral Vigor (Restoration talent)
-	[207498] = 207399, -- Ancestral Protection <- Ancestral Protection Totem (Restoration talent)
-	[208963] = 204330, -- Skyfury Totem (honor talent)
-	[208997] = 204331, -- Counterstrike Totem (honor talent)
-	[210652] = 210643, -- Storm Totem <- Totem Mastery (Elemental talent)
-	[210658] = 210643, -- Ember Totem <- Totem Mastery (Elemental talent)
-	[210659] = 210643, -- Tailwind Totem <- Totem Mastery (Elemental talent)
-	[210927] = 211062, -- Static Cling (Enhancement honor talent)
-	[211400] = 211062, -- Static Cling (Enhancement honor talent)
-	[215785] = 201900, -- Hot Hand (Enhacement talent)
-	[216251] = 200071, -- Undulation (Restoration talent)
-	[224125] = 262624, -- Molten Weapon <- Elemental Spirits (Enhancement talent)
-	[224127] = 262624, -- Crackling Surge <- Elemental Spirits (Enhancement talent)
-	[236502] = 236501, -- Tidebringer (Restoration honor talent)
-	[236746] = 204393, -- Control of Lava (Elemental honor talent)
-	[260734] =  16166, -- Master of the Elements (Elemental talent)
-	[260881] = 260878, -- Spirit Wolf (talent)
-	[262397] = 262395, -- Storm Totem <- Totem Mastery (Enhancement talent)
-	[262399] = 262395, -- Ember Totem <- Totem Mastery (Enhancement talent)
-	[262400] = 262395, -- Tailwind Totem <- Totem Mastery (Enhancement talent)
-	[262417] = 262395, -- Resonance Totem <- Totem Mastery (Enhancement talent)
-	[262652] = 262647, -- Forceful Winds (Enhancement talent)
-	[263806] = 192249, -- Wind Gust <- Storm Elemental (Elemental talent)
-	[268429] = 192087, -- Searing Assault (Enhancement talent)
-	[269808] = 260694, -- Exposed Elements (Elemental talent)
-	[271924] = 262624, -- Molten Weapon <- Elemental Spirits (Enhancement talent)
-	[273323] = 192106, -- Lightning Shield Overcharge <- Lightning Shield (Enhancement talent)
-	[280815] = 280614, -- Flash Flood (Restoration talent)
+	[204262] = 204261, -- Spectral Recovery (PvP Talent)
+	[204361] = 193876, -- Bloodlust <- Shamanism (Enhancement PvP Talent)
+	[204399] = 204398, -- Earthfury (Elemental PvP Talent)
+	[206647] = 206642, -- Electrocute (Restoration PvP Talent)
+	[207400] = 207401, -- Ancestral Vigor (Restoration Talent)
+	[207498] = 207399, -- Ancestral Protection <- Ancestral Protection Totem (Restoration Talent)
+	[208963] = 204330, -- Skyfury Totem (PvP Talent)
+	[208997] = 204331, -- Counterstrike Totem (PvP Talent)
+	[210927] = 211062, -- Static Cling (Enhancement PvP Talent)
+	[211400] = 211062, -- Static Cling (Enhancement PvP Talent)
+	[215785] = 201900, -- Hot Hand (Enhancement Talent)
+	[216251] = 200071, -- Undulation (Restoration Talent)
+	[224125] = 262624, -- Molten Weapon <- Elemental Spirits (Enhancement Talent)
+	[224127] = 262624, -- Crackling Surge <- Elemental Spirits (Enhancement Talent)
+	[236502] = 236501, -- Tidebringer (Restoration PvP Talent)
+	[236746] = 204393, -- Control of Lava (Elemental PvP Talent)
+	[260734] =  16166, -- Master of the Elements (Elemental Talent)
+	[260881] = 260878, -- Spirit Wolf (Talent)
+	[262652] = 262647, -- Forceful Winds (Enhancement Talent)
+	[263806] = 192249, -- Wind Gust <- Storm Elemental (Elemental Talent)
+	[268429] = 192087, -- Searing Assault (Enhancement Talent)
+	[269808] = 260694, -- Exposed Elements (Elemental Talent)
+	[271924] = 262624, -- Molten Weapon <- Elemental Spirits (Enhancement Talent)
+	[273323] = 192106, -- Lightning Shield Overcharge <- Lightning Shield (Enhancement Talent)
+	[280815] = 280614, -- Flash Flood (Restoration Talent)
+	[320763] =  16191, -- Mana Tide Totem (Restoration)
+	[327942] =   8512, -- Windfury Totem (Enhancement)
 }, {
 	-- map aura to modified spell(s)
 	[ 53390] =  { -- Tidal Waves (Restoration)
@@ -249,58 +242,50 @@ lib:__RegisterSpells('SHAMAN', 80000, 3, {
 		77472, -- Healing Wave
 	},
 	[ 77762] =  51505, -- Lava Surge (Elemental/Restoration) -> Lava Burst
-	[118297] = 118297, -- Immolate (Fire Elemental) (Elemental talent)
-	[118337] = 118337, -- Harden Skin (Earth Elemental) (Elemental talent)
-	[118345] = 118345, -- Pulverize (Earth Elemental) (Elemental talent)
-	[157348] = 157348, -- Call Lightning (Storm Elemental) (Elemental talent)
-	[157375] = 157375, -- Eye of the Storm (Storm Elemental) (Elemental talent)
-	[157504] = 201764, -- Cloudburst Totem (Restoration talent) -> Recall Cloudburst Totem
-	[191634] = { -- Stormkeeper (Elemental talent)
+	[118297] = 118297, -- Immolate (Fire Elemental) (Elemental Talent)
+	[118337] = 118337, -- Harden Skin (Earth Elemental) (Elemental Talent)
+	[118345] = 118345, -- Pulverize (Earth Elemental) (Elemental Talent)
+	[157348] = 157348, -- Call Lightning (Storm Elemental) (Elemental Talent)
+	[157375] = 157375, -- Eye of the Storm (Storm Elemental) (Elemental Talent)
+	[157504] = 201764, -- Cloudburst Totem (Restoration Talent) -> Recall Cloudburst Totem
+	[191634] = { -- Stormkeeper (Elemental Talent)
 		188196, -- Lighting Bolt
 		188443, -- Chain Lightning
 	},
 	[198300] =  17364, -- Gathering Storms -> Stormstrike (Enhancement)
-	[201846] =  {-- Landslide (Enhancement talent)
-		 17364, -- Stormstrike
-		115356, -- Windstrike (Enhancement talent) NOTE: when Ascendance is active
-	},
-	[202004] =  { -- Landslide (Enhancement talent)
-		 17364, -- Stormstrike
-		115356, -- Windstrike (Enhancement talent) NOTE: when Ascendance is active
-	},
-	[204262] =   2645, -- Spectral Recovery (honor talent) -> Ghost Wolf
-	[204361] = 204361, -- Bloodlust (Enhancement honor talent)
-	[204399] =   8042, -- Earthfury (Elemental honor talent) -> Earth Shock
-	[206647] =    370, -- Electrocute (Restoration honor talent) -> Purge
-	[207400] = { -- Ancestral Vigor (Restoration talent)
+	[204262] =   2645, -- Spectral Recovery (PvP Talent) -> Ghost Wolf
+	[204361] = 204361, -- Bloodlust (Enhancement PvP Talent)
+	[204399] =   8042, -- Earthfury (Elemental PvP Talent) -> Earth Shock
+	[206647] =    370, -- Electrocute (Restoration PvP Talent) -> Purge
+	[207400] = { -- Ancestral Vigor (Restoration Talent)
 		 1064, -- Chain Heal
 		 8004, -- Healing Surge
 		73920, -- Riptide
 		77472, -- Healing Wave
 	},
-	[210714] = 196840, -- Icefury (Elemental talent) -> Frost Shock
-	[210927] =  17364, -- Static Cling (Enhancement honor talent) -> Stormstrike NOTE: not with Windstrike
-	[211400] =  17364, -- Static Cling (Enhancement honor talent) -> Stormstrike NOTE: not with Windstrike
-	[215785] =  60103, -- Hot Hand (Enhacement talent) -> Lava Lash
-	[216251] = { -- Undulation (Restoration talent)
+	[210714] = 196840, -- Icefury (Elemental Talent) -> Frost Shock
+	[210927] =  17364, -- Static Cling (Enhancement PvP Talent) -> Stormstrike NOTE: not with Windstrike
+	[211400] =  17364, -- Static Cling (Enhancement PvP Talent) -> Stormstrike NOTE: not with Windstrike
+	[215785] =  60103, -- Hot Hand (Enhancement Talent) -> Lava Lash
+	[216251] = { -- Undulation (Restoration Talent)
 		 8004, -- Healing Surge
 		77472, -- Healing Wave
 	},
-	[224125] =  60103, -- Molten Weapon (Enhancement talent) -> Lava Lash
-	[224127] =  17364, -- Crackling Surge (Enhancement talent) -> Stormstrike
-	[236502] =   1064, -- Tidebringer (Restoration honor talent) -> Chain Heal
-	[236746] =  51505, -- Control of Lava (Elemental honor talent) -> Lava Burst
-	[260734] =  51505, -- Master of the Elements (Elemental talent) -> Lava Burst
-	[260881] =   2645, -- Spirit Wolf (talent)
-	[262652] =   6603, -- Forceful Winds (Enhancement talent) -> Auto Attack NOTE: Windfury
-	[263806] = { -- Wind Gust (Elemental talent)
+	[224125] =  60103, -- Molten Weapon (Elemental Spirits - Enhancement Talent) -> Lava Lash
+	[224127] =  17364, -- Crackling Surge (Enhancement Talent) -> Stormstrike
+	[236502] =   1064, -- Tidebringer (Restoration PvP Talent) -> Chain Heal
+	[236746] =  51505, -- Control of Lava (Elemental PvP Talent) -> Lava Burst
+	[260734] =  51505, -- Master of the Elements (Elemental Talent) -> Lava Burst
+	[260881] =   2645, -- Spirit Wolf (Talent)
+	[262652] =   6603, -- Forceful Winds (Enhancement Talent) -> Auto Attack NOTE: Windfury
+	[263806] = { -- Wind Gust (Elemental Talent)
 		188196, -- Lighting Bolt
 		188443, -- Chain Lightning
 	},
-	[268429] = 193796, -- Searing Assault (Enhancement talent) -> Flametongue
-	[269808] = 188196, -- Exposed Elements (Elemental talent) -> Lightning Bolt
-	[271924] =  60103, -- Molten Weapon (Enhancement talent) -> Lava Lash
-	[280815] = { -- Flash Flood (Restoration talent)
+	[268429] = 193796, -- Searing Assault (Enhancement Talent) -> Flametongue
+	[269808] = 188196, -- Exposed Elements (Elemental Talent) -> Lightning Bolt
+	[271924] =  60103, -- Molten Weapon (Elemental Spirits - Enhancement Talent) -> Lava Lash
+	[280815] = { -- Flash Flood (Restoration Talent)
 		  1064, -- Chain Heal
 		  8004, -- Healing Surge
 		 73920, -- Healing Rain


### PR DESCRIPTION
Shaman Flametongue and Windfury 'Weapon Imbues' missing. DK, Blood Only.