### PR TITLE
Update priest for 9.0.2

### DIFF
--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -89,7 +89,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 					 33206, -- Pain Suppression (Discipline)
 					 47788, -- Guardian Spirit (Holy)
 					 81782, -- Power Word: Barrier (Discipline)
-					271466, -- Luminous Barrier (Discipline talent)
+					109964, -- Spirit Shell (Discipline talent)
 				},
 			},
 			PERSONAL = {

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -149,6 +149,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 			198069, -- Power of the Dark Side (Discipline)
 			232698, -- Shadowform (Shadow)
 			247776, -- Mind Trauma (Shadow honor talent)
+			341205, -- Dark Thoughts (Shadow)
 		},
 	},
 	DISPEL = {
@@ -198,6 +199,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 	[247776] = 199445, -- Mind Trauma (Shadow honor talent)
 	[263406] = 193223, -- Surrendered to Madness <- Surrender to Madness (Shadow talent)
 	[289655] = 289657, -- Holy Word: Concentration (Holy honor talent)
+	[341207] = 341205, -- Dark Thoughts (Shadow)
 }, { -- map aura(s) to modified spell(s)
 	[ 65081] = { -- Body and Soul (Discipline/Shadow talent)
 		   17, -- Power Word: Shield (Discipline/Shadow)
@@ -228,4 +230,5 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 	[215769] = 215769, -- Spirit of Redemption (Holy honor talent)
 	[215962] =   2060, -- Inspiration (Holy honor talent) -> Heal
 	[247776] =  15407, -- Mind Trauma (Shadow honor talent) -> Mind Flay
+	[341207] =   8092, -- Dark Thoughts (Shadow) -> Mind Blast
 })

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -33,7 +33,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		 120517, -- Halo (Discipline/Holy talent)
 		 123040, -- Mindbender (Discipline talent)
 		 129250, -- Power Word: Solace (Discipline talent)
-		 204883, -- Circle of Healing (Holy talent)
+		 204883, -- Circle of Healing 
 		 205351, -- Shadow Word: Void (Shadow talent)
 		 205385, -- Shadow Crash (Shadow talent)
 		 205448, -- Void Bolt (Shadow)

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -42,6 +42,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		 265202, -- Holy Word: Salvation (Holy talent)
 		 280711, -- Dark Ascension (Shadow talent)
 		 305498, -- Premonition (Discipline honor talent)
+		 341374, -- Damnation (Shadow talent)
 		[ 15487] = 'INTERRUPT', -- Silence (Shadow)
 		AURA = {
 			HARMFUL = {

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -51,6 +51,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 				205369, -- Mind Bomb (Shadow talent)
 				214621, -- Schism (Discipline talent)
 				263165, -- Void Torrent (Shadow talent)
+				323673, -- Mindgames (Venthyr covenant ability)
 				CROWD_CTRL = {
 					[200196] = 'INCAPACITATE', -- Holy Word: Chastise
 					DISORIENT = {

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -102,7 +102,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 					197871, -- Dark Archangel (Discipline honor talent)
 				},
 				SURVIVAL = {
-					 19236, -- Desperate Prayer (Discipline/Holy)
+					 19236, -- Desperate Prayer 
 					 47585, -- Dispersion (Shadow)
 					196773, -- Inner Focus (Holy honor talent)
 					213602, -- Greater Fade (Holy/Shadow honor talent)

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -45,6 +45,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		[ 15487] = 'INTERRUPT', -- Silence (Shadow)
 		AURA = {
 			HARMFUL = {
+				   453, -- Mind Soothe
 				 14914, -- Holy Fire (Holy)
 				205369, -- Mind Bomb (Shadow talent)
 				214621, -- Schism (Discipline talent)

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -68,6 +68,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 			},
 			HELPFUL = {
 				     17, -- Power Word: Shield (Discipline/Shadow)
+				  10060, -- Power Infusion
 				  41635, -- Prayer of Mending (Holy)
 				  64844, -- Divine Hymn (Holy)
 				 121557, -- Angelic Feather (Discipline/Holy talent)

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -23,7 +23,7 @@ if not lib then return end
 lib:__RegisterSpells('PRIEST', 90002, 3, {
 	COOLDOWN = {
 		   2050, -- Holy Word: Serenity (Holy)
-		   8092, -- Mind Blast 
+		   8092, -- Mind Blast
 		  32379, -- Shadow Word: Death
 		  34433, -- Shadowfiend (Discipline/Shadow)
 		  34861, -- Holy Word: Sanctify (Holy)
@@ -33,7 +33,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		 120517, -- Halo (Discipline/Holy talent)
 		 123040, -- Mindbender (Discipline talent)
 		 129250, -- Power Word: Solace (Discipline talent)
-		 204883, -- Circle of Healing 
+		 204883, -- Circle of Healing
 		 205351, -- Shadow Word: Void (Shadow talent)
 		 205385, -- Shadow Crash (Shadow talent)
 		 205448, -- Void Bolt (Shadow)
@@ -106,7 +106,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 					197871, -- Dark Archangel (Discipline honor talent)
 				},
 				SURVIVAL = {
-					 19236, -- Desperate Prayer 
+					 19236, -- Desperate Prayer
 					 47585, -- Dispersion (Shadow)
 					196773, -- Inner Focus (Holy honor talent)
 					213602, -- Greater Fade (Holy/Shadow honor talent)
@@ -120,7 +120,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 	},
 	AURA = {
 		HARMFUL = {
-			   589, -- Shadow Word: Pain 
+			   589, -- Shadow Word: Pain
 			 34914, -- Vampiric Touch (Shadow)
 			 48045, -- Mind Sear (Shadow)
 			204213, -- Purge the Wicked (Discipline talent)
@@ -167,8 +167,8 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		},
 	},
 }, { -- map aura to provider(s)
-	[   589] = { -- Shadow Word: Pain 
-		   589, -- Shadow Word: Pain 
+	[   589] = { -- Shadow Word: Pain
+		   589, -- Shadow Word: Pain
 		263346, -- Dark Void (Shadow talent)
 	},
 	[  6788] =     17, -- Weakened Soul <- Power Word: shield

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -20,7 +20,7 @@ along with LibPlayerSpells-1.0. If not, see <http://www.gnu.org/licenses/>.
 
 local lib = LibStub('LibPlayerSpells-1.0')
 if not lib then return end
-lib:__RegisterSpells('PRIEST', 80200, 2, {
+lib:__RegisterSpells('PRIEST', 90002, 3, {
 	COOLDOWN = {
 		   2050, -- Holy Word: Serenity (Holy)
 		   8092, -- Mind Blast (Shadow)

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -24,7 +24,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 	COOLDOWN = {
 		   2050, -- Holy Word: Serenity (Holy)
 		   8092, -- Mind Blast (Shadow)
-		  32379, -- Shadow Word: Death (Shadow talent)
+		  32379, -- Shadow Word: Death
 		  34433, -- Shadowfiend (Discipline/Shadow)
 		  34861, -- Holy Word: Sanctify (Holy)
 		  73325, -- Leap of Faith

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -119,7 +119,7 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 	},
 	AURA = {
 		HARMFUL = {
-			   589, -- Shadow Word: Pain (Discipline/Shadow)
+			   589, -- Shadow Word: Pain 
 			 34914, -- Vampiric Touch (Shadow)
 			 48045, -- Mind Sear (Shadow)
 			204213, -- Purge the Wicked (Discipline talent)
@@ -166,8 +166,8 @@ lib:__RegisterSpells('PRIEST', 90002, 3, {
 		},
 	},
 }, { -- map aura to provider(s)
-	[   589] = { -- Shadow Word: Pain (Discipline/Shadow)
-		   589, -- Shadow Word: Pain (Discipline/Shadow)
+	[   589] = { -- Shadow Word: Pain 
+		   589, -- Shadow Word: Pain 
 		263346, -- Dark Void (Shadow talent)
 	},
 	[  6788] =     17, -- Weakened Soul <- Power Word: shield

--- a/data/Priest.lua
+++ b/data/Priest.lua
@@ -23,7 +23,7 @@ if not lib then return end
 lib:__RegisterSpells('PRIEST', 90002, 3, {
 	COOLDOWN = {
 		   2050, -- Holy Word: Serenity (Holy)
-		   8092, -- Mind Blast (Shadow)
+		   8092, -- Mind Blast 
 		  32379, -- Shadow Word: Death
 		  34433, -- Shadowfiend (Discipline/Shadow)
 		  34861, -- Holy Word: Sanctify (Holy)


### PR DESCRIPTION
This PR updates `data/Priest.lua` with changes from 9.0.2 for Shadowlands

## Updates In Detail
- Updated the spell database according to the changes published in the wowhead.com guide for [shadow](https://www.wowhead.com/shadow-priest-guide#changes), [holy](https://www.wowhead.com/holy-priest-guide#whats-changed-in-shadowlands), and [discipline](https://www.wowhead.com/discipline-priest-guide#whats-changed-in-shadowlands)
- Updated comments where spec-specific spells were made baseline
- Added the [Mindgames](https://www.wowhead.com/spell=323673/mindgames) Venthyr covenant spell.

## Missing Spells
- This PR does _not_ add the covenant abilities from other covenants -- I don't have the characters to test those.